### PR TITLE
improved collection of failed specs

### DIFF
--- a/src/failed-spec-parser.js
+++ b/src/failed-spec-parser.js
@@ -1,13 +1,15 @@
-const FAILED_LINE = /at \[object Object\]\.<anonymous> \((.*)\)/g;
+const FAILED_LINES = /at \[object Object\]\.<anonymous> \((.*?):.*\)/g;
 
 export default function (output = '') {
-  // this could all probably fit into one regex...
-  var failedSpecLines = output.match(FAILED_LINE);
+  var output = arguments.length <= 0 || arguments[0] === undefined ? '' : arguments[0];
 
-  if (!failedSpecLines) { return []; }
-
-  return failedSpecLines.map(function (line) {
-    let path = line.match(/\((.*):/)[1];
-    return path.slice(0, [path.length - 2]);
-  });
-}
+  var failedSpecLines = [];
+  var match;
+  //iterate over all matches and prevent adding a spec twice (e.g. when using multiCapabilities)
+  while (match = FAILED_LINES.exec(output)) {
+    if (failedSpecLines.indexOf(match[1]) == -1) {
+      failedSpecLines.push(match[1]);
+    }
+  }
+  return failedSpecLines;
+};


### PR DESCRIPTION
regex now matches lazy (using '?' after '*' in group) instead of greedy avoiding the need for result slicing and potential problems with multidigit line numbers
failed specs only get added once (especially important when using multiCapabilities)
