### PR TITLE
Add support for parsing cucumberjs output

### DIFF
--- a/src/failed-spec-parser.js
+++ b/src/failed-spec-parser.js
@@ -1,13 +1,21 @@
 export default function (output = '') {
   let match = null;
-  let FAILED_LINES = /at \[object Object\]\.<anonymous> \((([A-Z]:\\)?.*?):.*\)/g;
+  let CUCUMBERJS_TEST = /^\d+ scenarios?/m
   let failedSpecs = new Set();
 
-  while (match = FAILED_LINES.exec(output)) {
-    // windows output includes stack traces from
-    // webdriver so we filter those out here
-    if (!/node_modules/.test(match[1])) {
+  if (CUCUMBERJS_TEST.test(output)) {
+    let FAILED_LINES = /(.*?):\d+ # Scenario:.*/g;
+    while (match = FAILED_LINES.exec(output)) {
       failedSpecs.add(match[1]);
+    }
+  } else {
+    let FAILED_LINES = /at \[object Object\]\.<anonymous> \((([A-Z]:\\)?.*?):.*\)/g;
+    while (match = FAILED_LINES.exec(output)) {
+      // windows output includes stack traces from
+      // webdriver so we filter those out here
+      if (!/node_modules/.test(match[1])) {
+        failedSpecs.add(match[1]);
+      }
     }
   }
 

--- a/test/failed-spec-parser.test.js
+++ b/test/failed-spec-parser.test.js
@@ -19,6 +19,14 @@ describe('failed spec parser', () => {
     ]);
   });
 
+  it('properly identifies failed cucumberjs feature files', () => {
+    let output = readFixture('failed-cucumberjs-output.txt');
+
+    expect(failedSpecParser(output)).to.eql([
+      '/Users/jrust/code/features/automated/fail.feature'
+    ]);
+  });
+
   it('handles output on windows', function () {
     let output = readFixture('failed-windows-test-output.txt');
 
@@ -59,6 +67,12 @@ describe('failed spec parser', () => {
       object Object
       Wow
     `
+
+    expect(failedSpecParser(output)).to.eql([]);
+  });
+
+  it('returns an empty array if cucumberjs output has no matches', () => {
+    let output = readFixture('success-cucumberjs-output.txt');
 
     expect(failedSpecParser(output)).to.eql([]);
   });

--- a/test/support/fixtures/failed-cucumberjs-output.txt
+++ b/test/support/fixtures/failed-cucumberjs-output.txt
@@ -1,0 +1,21 @@
+[launcher] Running 1 instances of WebDriver
+Feature: Failing stuff
+
+
+
+  Scenario: Flakey scenario              # features/automated/fail.feature:4
+    Then it fails in a consistent manner # features/automated/fail.feature:5
+      AssertionError: expected false to be true
+
+(::) failed steps (::)
+
+AssertionError: expected false to be true
+
+
+Failing scenarios:
+/Users/jrust/code/features/automated/fail.feature:4 # Scenario: Flakey scenario
+
+1 scenario (1 failed)
+1 step (1 failed)
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #1 failed 2 test(s)

--- a/test/support/fixtures/success-cucumberjs-output.txt
+++ b/test/support/fixtures/success-cucumberjs-output.txt
@@ -1,0 +1,13 @@
+[launcher] Running 1 instances of WebDriver
+@testing
+Feature: Working stuff
+
+
+
+  Scenario: Good scenario                   # features/automated/success.feature:4
+    Then it succeeds in a consistent manner # features/automated/success.feature:5
+
+
+1 scenario (1 passed)
+1 step (1 passed)
+[launcher] 0 instance(s) of


### PR DESCRIPTION
Adds support for [cucumber-js](https://github.com/cucumber/cucumber-js) output.  Tested against protractor running cucumber-js and chai and flake worked great.
