### PR TITLE
feat: allow flake to run on windows without protractor-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Via the CLI:
 npm i -g protractor-flake
 
 # protractor-flake <protractor-flake-options> -- <options to be passed to protractor>
-protractor-flake --protractor-path ./node_modules/.bin/protractor --max-attempts=3 -- protractor.conf.js
+protractor-flake --node-bin node --max-attempts=3 -- protractor.conf.js
 ```
 
 Protractor flake expects `protractor` to be on $PATH by default, but you can use the `--protractor-path` argument to point to the protractor executable.
@@ -32,10 +32,9 @@ var protractorFlake = require('protractor-flake');
 
 protractorFlake({
   maxAttempts: 3,
-  // expects protractor to be in path
-  // set this to wherever the protractor bin
-  // is located
-  protractorPath: 'protractor',
+  // expects node to be in path
+  // set this to wherever the node bin is located
+  nodeBin: 'node',
   protractorArgs: []
 }, function (status, output) {
   process.exit(status);

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "minimist": "^1.1.2",
     "core-js": "^0.9.18"
   },
+  "peerDependencies": {
+    "protractor": "2.x"
+  },
   "keywords": [
     "protractor",
     "flake",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import {spawn} from 'child_process';
+import {resolve} from 'path'
 import 'core-js/shim'
 import failedSpecParser from './failed-spec-parser';
 import log from './logger';
@@ -6,8 +7,8 @@ import log from './logger';
 const DEFAULT_PROTRACTOR_ARGS = [];
 
 const DEFAULT_OPTIONS = {
+  nodeBin: 'node',
   maxAttempts: 3,
-  protractorPath:  'protractor',
   '--': DEFAULT_PROTRACTOR_ARGS,
   protractorArgs: DEFAULT_PROTRACTOR_ARGS
 };
@@ -35,7 +36,12 @@ export default function (options = {}, callback = function noop () {}) {
   }
 
   function startProtractor(specFiles = []) {
-    let protractorArgs = parsedOptions.protractorArgs;
+    // '.../node_modules/protractor/lib/protractor.js'
+    var protractorMainPath = require.resolve('protractor');
+    // '.../node_modules/protractor/bin/protractor'
+    var protractorBinPath = resolve(protractorMainPath, '../../bin/protractor');
+
+    let protractorArgs = [protractorBinPath].concat(parsedOptions.protractorArgs);
     let output = '';
 
     if (specFiles.length) {
@@ -44,7 +50,7 @@ export default function (options = {}, callback = function noop () {}) {
     }
 
     let protractor = spawn(
-      parsedOptions.protractorPath,
+      parsedOptions.nodeBin,
       protractorArgs,
       options.protractorSpawnOptions
     );


### PR DESCRIPTION
This resolves #3 by using the same method as [grunt-protractor-runner](https://github.com/teerapap/grunt-protractor-runner) for launching protractor.  I've tested on windows and linux and it now runs successfully on both without any extra arguments.  Unfortunately the integration tests still fail on windows for the same reason (`spawn` :cry:).  I tried to use the same method of using node to launch protractor-runner in the integration tests, but it still wouldn't take on windows.  Anyhow, on to the details:

The protractor path is now auto-set by making it a requirement in
package.json and using `resolve` to find the path. Protractor is then
launched using node which solves the problem where Windows has trouble
launching spawned commands.

`protractor-path` option has thus been removed in favor of a
`node-bin` option.
