### PR TITLE
Adding Support for --protractor-path parameter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,10 +36,15 @@ export default function (options = {}, callback = function noop () {}) {
   }
 
   function startProtractor (specFiles = []) {
-    // '.../node_modules/protractor/lib/protractor.js'
-    var protractorMainPath = require.resolve('protractor')
-    // '.../node_modules/protractor/bin/protractor'
-    var protractorBinPath = resolve(protractorMainPath, '../../bin/protractor')
+    var protractorBinPath
+    if (parsedOptions.protractorPath) {
+      protractorBinPath = resolve(parsedOptions.protractorPath)
+    } else {
+      // '.../node_modules/protractor/lib/protractor.js'
+      var protractorMainPath = require.resolve('protractor')
+      // '.../node_modules/protractor/bin/protractor'
+      protractorBinPath = resolve(protractorMainPath, '../../bin/protractor')
+    }
 
     let protractorArgs = [protractorBinPath].concat(parsedOptions.protractorArgs)
     let output = ''

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -121,6 +121,12 @@ describe('Protractor Flake', () => {
   })
 
   context('options', () => {
+    it('allows a different path for protractor by using protractorPath option', () => {
+      protractorFlake({protractorPath: '/arbitrary/path/to/protractor'})
+
+      expect(spawnStub).to.have.been.calledWith('node', ['/arbitrary/path/to/protractor'])
+    })
+
     it('allows a different path for node by using nodeBin option', () => {
       protractorFlake({nodeBin: '/path/node'})
 


### PR DESCRIPTION
This functionality was apparently not actually available, despite the documentation noting it.  I've added the codefix to make this parameter to function as expected.

Also, I added a version parameter to package.json, since I was unable to install the package via npm without it.  Considering the latest package was noted as 1.0.3, I figured 1.0.4 was safe.
