### PR TITLE
Log protractor error output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,12 @@ export default function (options = {}, callback = function noop () {}) {
       output = output + text
     })
 
+    protractor.stderr.on('data', (buffer) => {
+      let text = buffer.toString()
+      log('info', text)
+      output = output + text
+    })
+
     protractor.on('exit', function (status) {
       handleTestEnd(status, output)
     })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -22,6 +22,11 @@ describe('Protractor Flake', () => {
         on (event, callback) {
           spawnStub.dataCallback = callback
         }
+      },
+      stderr: {
+        on (event, callback) {
+          spawnStub.dataCallback = callback
+        }
       }
     })
 


### PR DESCRIPTION
This logs any stderr output from the protractor child process. Currently when protractor fails the output is swallowed by flake.

I didn't really see a great way to test this with the existing suite but if you've got something in mind I'd be happy to add them.
