### PR TITLE
feat: fix skipping UnknownError tests

### DIFF
--- a/src/failed-spec-parser.js
+++ b/src/failed-spec-parser.js
@@ -18,6 +18,16 @@ export default function (output = '') {
       }
     }
   }
+  let FAILED_UNEXPECTED = /UnknownError:/g
+  while (match = FAILED_UNEXPECTED.exec(output)) { // eslint-disable-line no-cond-assign
+    // specfiles can not be discovered with UnknownErrors
+    // so we reset the entire failedSpecs
+    // to make sure these specs are not skipped
+    if (!/node_modules/.test(match[1])) {
+      console.log('Something terrible happened (UnknownError found), clearing failedSpecs')
+      failedSpecs = new Set()
+    }
+  }
 
   return [...failedSpecs]
 }

--- a/test/failed-spec-parser.test.js
+++ b/test/failed-spec-parser.test.js
@@ -85,4 +85,10 @@ describe('failed spec parser', () => {
       '/Users/ntomlin/workspace/protractor-flake/test/support/flakey.test.js'
     ])
   })
+
+  it('clears failedspecs if an UnknownError occurs', () => {
+    let output = readFixture('sharded-unknown-test-output.txt')
+
+    expect(failedSpecParser(output)).to.eql([])
+  })
 })

--- a/test/support/fixtures/sharded-unknown-test-output.txt
+++ b/test/support/fixtures/sharded-unknown-test-output.txt
@@ -1,0 +1,78 @@
+[launcher] Running 2 instances of WebDriver
+.
+------------------------------------
+/Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/protractor/node_modules/selenium-webdriver/lib/atoms/error.js:108
+  var template = new Error(this.message);
+                 ^
+UnknownError: Error forwarding the new session cannot find : Capabilities [{count=1, ie.ensureCleanSession=true, browserName=chrome, maxInstances=1, shardTestFiles=false, version=FR}]
+    at new bot.Error (/Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/protractor/node_modules/selenium-webdriver/lib/atoms/error.js:108:18)
+    at Object.bot.response.checkResponse (/Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/protractor/node_modules/selenium-webdriver/lib/atoms/response.js:109:9)
+    at /Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/protractor/node_modules/selenium-webdriver/lib/webdriver/webdriver.js:160:24
+    at [object Object].promise.Promise.goog.defineClass.invokeCallback_ (/Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/protractor/node_modules/selenium-webdriver/lib/goog/../webdriver/promise.js:1337:14)
+    at [object Object].promise.ControlFlow.goog.defineClass.goog.defineClass.abort_.error.executeNext_.execute_ (/Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/protractor/node_modules/selenium-webdriver/lib/goog/../webdriver/promise.js:2776:14)
+    at [object Object].promise.ControlFlow.goog.defineClass.goog.defineClass.abort_.error.executeNext_ (/Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/protractor/node_modules/selenium-webdriver/lib/goog/../webdriver/promise.js:2758:21)
+    at goog.async.run.processWorkQueue (/Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/protractor/node_modules/selenium-webdriver/lib/goog/async/run.js:124:15)
+    at process._tickCallback (node.js:369:9)
+From: Task: WebDriver.createSession()
+    at Function.webdriver.WebDriver.acquireSession_ (/Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/protractor/node_modules/selenium-webdriver/lib/webdriver/webdriver.js:157:22)
+    at Function.webdriver.WebDriver.createSession (/Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/protractor/node_modules/selenium-webdriver/lib/webdriver/webdriver.js:131:30)
+    at [object Object].Builder.build (/Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/protractor/node_modules/selenium-webdriver/builder.js:445:22)
+    at [object Object].DriverProvider.getNewDriver (/Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/protractor/lib/driverProviders/driverProvider.js:42:27)
+    at [object Object].Runner.createBrowser (/Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/protractor/lib/runner.js:190:37)
+    at /Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/protractor/lib/runner.js:280:21
+    at _fulfilled (/Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/q/q.js:834:54)
+    at self.promiseDispatch.done (/Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/q/q.js:863:30)
+    at Promise.promise.promiseDispatch (/Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/q/q.js:796:13)
+    at /Users/finkingma/ZorgDomein/zd-transaction-application/viewtest/node_modules/q/q.js:556:49
+[launcher] Process exited with error code 1
+
+[launcher] 2 instance(s) of WebDriver still running
+F
+------------------------------------
+[chrome #1-0] PID: 9864
+[chrome #1-0] Specs: /Users/ntomlin/workspace/protractor-flake/test/support/a-flakey.test.js
+[chrome #1-0] 
+[chrome #1-0] Using ChromeDriver directly...
+[chrome #1-0] [31mF[0m
+[chrome #1-0] 
+[chrome #1-0] Failures:
+[chrome #1-0] 
+[chrome #1-0]   1) a flakey integration test fails, in a horribly consistent manner
+[chrome #1-0]    Message:
+[chrome #1-0]      [31mExpected false to be truthy.[0m
+[chrome #1-0]    Stacktrace:
+[chrome #1-0]      Error: Failed expectation
+[chrome #1-0]     at [object Object].<anonymous> (/Users/ntomlin/workspace/protractor-flake/test/support/a-flakey.test.js:9:39)
+[chrome #1-0] 
+[chrome #1-0] Finished in 1.021 seconds
+[chrome #1-0] [31m1 test, 1 assertion, 1 failure
+[0m[chrome #1-0] 
+
+[launcher] 1 instance(s) of WebDriver still running
+F
+------------------------------------
+[chrome #1-2] PID: 9893
+[chrome #1-2] Specs: /Users/ntomlin/workspace/protractor-flake/test/support/another-flakey.test.js
+[chrome #1-2] 
+[chrome #1-2] Using ChromeDriver directly...
+[chrome #1-2] [31mF[0m
+[chrome #1-2] 
+[chrome #1-2] Failures:
+[chrome #1-2] 
+[chrome #1-2]   1) another flakey integration test fails, in a horribly consistent manner
+[chrome #1-2]    Message:
+[chrome #1-2]      [31mExpected false to be truthy.[0m
+[chrome #1-2]    Stacktrace:
+[chrome #1-2]      Error: Failed expectation
+[chrome #1-2]     at [object Object].<anonymous> (/Users/ntomlin/workspace/protractor-flake/test/support/another-flakey.test.js:9:39)
+[chrome #1-2] 
+[chrome #1-2] Finished in 0.558 seconds
+[chrome #1-2] [31m1 test, 1 assertion, 1 failure
+[0m[chrome #1-2] 
+
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #1-1 passed
+[launcher] chrome #1-0 failed 1 test(s)
+[launcher] chrome #1-2 failed 1 test(s)
+[launcher] overall: 2 failed spec(s)
+[launcher] Process exited with error code 1


### PR DESCRIPTION
Hey,

For the Handling webdriver timeouts I created this PR.
Problem was that when spec run as followed:
1) Spec check fails.
2) web driver timeout
Only spec 1 will be logged to rerun. If spec 1 passes, the run will be 'passed', but spec 2 has been skipped, because no filename could be discovered.

This fix is to clear the entire failedSpecs once an UnknownError occurs, to make sure all tests are rerun once more.

New unit test added for this feature as well.
