### PR TITLE
feat: also include errored specfiles when using sharding

### DIFF
--- a/src/failed-spec-parser.js
+++ b/src/failed-spec-parser.js
@@ -2,8 +2,34 @@ export default function (output = '') {
   let match = null
   let CUCUMBERJS_TEST = /^\d+ scenarios?/m
   let failedSpecs = new Set()
+  let PROTRACTOR_SHARDED = /------------------------------------/g
+  let SPECFILE_REG = /.+Specs:\s(.*\.js)/g
 
-  if (CUCUMBERJS_TEST.test(output)) {
+  if (PROTRACTOR_SHARDED.test(output) && SPECFILE_REG.test(output)) {
+    console.log('sharded test found')
+    let testsOutput = output.split('------------------------------------')
+    testsOutput.shift()
+    let RESULT_REG = /\d+\sspec|assertions?,\s(\d+)\sfailures?/g
+    testsOutput.forEach(function (test) {
+      let specfile
+      let result = 'failed'
+      // retrieve specfile from run;
+      while (match = SPECFILE_REG.exec(test)) { // eslint-disable-line no-cond-assign
+        specfile = match[1]
+      }
+      // check for string 'X specs, X failures' and verify that failures === 0;
+      while (match = RESULT_REG.exec(test)) { // eslint-disable-line no-cond-assign
+        if (match[1] === '0') {
+          result = 'passed'
+        }
+      }
+      if (result === 'failed') {
+        if (!/node_modules/.test(specfile)) {
+          failedSpecs.add(specfile)
+        }
+      }
+    })
+  } else if (CUCUMBERJS_TEST.test(output)) {
     let FAILED_LINES = /(.*?):\d+ # Scenario:.*/g
     while (match = FAILED_LINES.exec(output)) { // eslint-disable-line no-cond-assign
       failedSpecs.add(match[1])

--- a/src/failed-spec-parser.js
+++ b/src/failed-spec-parser.js
@@ -2,10 +2,10 @@ export default function (output = '') {
   let match = null
   let CUCUMBERJS_TEST = /^\d+ scenarios?/m
   let failedSpecs = new Set()
-  let PROTRACTOR_SHARDED = /------------------------------------/g
+  let MULTI_TESTS = /------------------------------------/g
   let SPECFILE_REG = /.+Specs:\s(.*\.js)/g
 
-  if (PROTRACTOR_SHARDED.test(output) && SPECFILE_REG.test(output)) {
+  if (MULTI_TESTS.test(output) && SPECFILE_REG.test(output)) {
     let testsOutput = output.split('------------------------------------').slice(1)
 
     let RESULT_REG = /,\s(\d+)\sfailures?/g

--- a/src/failed-spec-parser.js
+++ b/src/failed-spec-parser.js
@@ -8,7 +8,7 @@ export default function (output = '') {
   if (MULTI_TESTS.test(output) && SPECFILE_REG.test(output)) {
     let testsOutput = output.split('------------------------------------').slice(1)
 
-    let RESULT_REG = /,\s(\d+)\sfailures?/g
+    let RESULT_REG = /,\s0 failures/g
     testsOutput.forEach(function (test) {
       let specfile
       let result = 'failed'
@@ -18,9 +18,7 @@ export default function (output = '') {
       }
       // check for string 'X specs, X failures' and verify that failures === 0;
       while (match = RESULT_REG.exec(test)) { // eslint-disable-line no-cond-assign
-        if (match[1] === '0') {
-          result = 'passed'
-        }
+        result = 'passed'
       }
       if (result === 'failed') {
         if (!/node_modules/.test(specfile)) {

--- a/src/failed-spec-parser.js
+++ b/src/failed-spec-parser.js
@@ -3,7 +3,7 @@ export default function (output = '') {
   let CUCUMBERJS_TEST = /^\d+ scenarios?/m
   let failedSpecs = new Set()
   let PROTRACTOR_SHARDED = /------------------------------------/g
-  let SPECFILE_REG = /.*Specs:\s(.*\.js)/g
+  let SPECFILE_REG = /.+Specs:\s(.*\.js)/g
 
   if (PROTRACTOR_SHARDED.test(output) && SPECFILE_REG.test(output)) {
     let testsOutput = output.split('------------------------------------').slice(1)

--- a/src/failed-spec-parser.js
+++ b/src/failed-spec-parser.js
@@ -3,13 +3,12 @@ export default function (output = '') {
   let CUCUMBERJS_TEST = /^\d+ scenarios?/m
   let failedSpecs = new Set()
   let PROTRACTOR_SHARDED = /------------------------------------/g
-  let SPECFILE_REG = /.+Specs:\s(.*\.js)/g
+  let SPECFILE_REG = /.*Specs:\s(.*\.js)/g
 
   if (PROTRACTOR_SHARDED.test(output) && SPECFILE_REG.test(output)) {
-    console.log('sharded test found')
-    let testsOutput = output.split('------------------------------------')
-    testsOutput.shift()
-    let RESULT_REG = /\d+\sspec|assertions?,\s(\d+)\sfailures?/g
+    let testsOutput = output.split('------------------------------------').slice(1)
+
+    let RESULT_REG = /,\s(\d+)\sfailures?/g
     testsOutput.forEach(function (test) {
       let specfile
       let result = 'failed'

--- a/test/failed-spec-parser.test.js
+++ b/test/failed-spec-parser.test.js
@@ -86,12 +86,20 @@ describe('failed spec parser', () => {
     ])
   })
 
-  it('properly handles error output', function () {
+  it('properly handles error output in sharded tests', function () {
     let output = readFixture('sharded-error-test-output.txt')
 
     expect(failedSpecParser(output)).to.eql([
       '/Users/ntomlin/workspace/protractor-flake/test/support/a-flakey.test.js',
       '/Users/ntomlin/workspace/protractor-flake/test/support/another-flakey.test.js'
+    ])
+  })
+
+  it('properly handles error output in multicapabilities tests', function () {
+    let output = readFixture('multicapabilities-withspecs.txt')
+
+    expect(failedSpecParser(output)).to.eql([
+      '/Users/ntomlin/workspace/protractor-flake/test/support/a-flakey.test.js'
     ])
   })
 })

--- a/test/failed-spec-parser.test.js
+++ b/test/failed-spec-parser.test.js
@@ -85,4 +85,13 @@ describe('failed spec parser', () => {
       '/Users/ntomlin/workspace/protractor-flake/test/support/flakey.test.js'
     ])
   })
+
+  it('properly handles error output', function () {
+    let output = readFixture('sharded-error-test-output.txt')
+
+    expect(failedSpecParser(output)).to.eql([
+      '/Users/ntomlin/workspace/protractor-flake/test/support/a-flakey.test.js',
+      '/Users/ntomlin/workspace/protractor-flake/test/support/another-flakey.test.js'
+    ])
+  })
 })

--- a/test/support/fixtures/multicapabilities-withspecs.txt
+++ b/test/support/fixtures/multicapabilities-withspecs.txt
@@ -1,0 +1,66 @@
+### Running local browser against local transaction application ###
+Version 3.1.1
+Report destination:   target/reports/report.html
+[launcher] Running 2 instances of WebDriver
+........
+------------------------------------
+[chrome #1] PID: 58317
+[chrome #1] Specs: /Users/ntomlin/workspace/protractor-flake/test/support/a-working.test.js
+[chrome #1]
+[chrome #1] Using ChromeDriver directly...
+[chrome #1] Spec started
+[chrome #1] Started
+[chrome #1]
+[chrome #1]   The Cluster Create Page
+[chrome #1]     ✓ only saves after proper validation
+[chrome #1] .
+[chrome #1] Executed 1 of 1 specs SUCCESS in 21 secs.
+[chrome #1]
+[chrome #1]
+[chrome #1]
+[chrome #1] 1 specs, 0 failures
+[chrome #1] Finished in 20.561 seconds
+[chrome #1] Fetching browser logs...
+[chrome #1] Done fetching browser logs.
+
+[launcher] 1 instance(s) of WebDriver still running
+
+------------------------------------
+[firefox #2] PID: 58318
+[firefox #2] Specs: /Users/ntomlin/workspace/protractor-flake/test/support/a-flakey.test.js
+[firefox #2]
+[firefox #2] Using FirefoxDriver directly...
+[firefox #2]
+[firefox #2] /usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/http/util.js:89
+[firefox #2]           Error('Timed out waiting for the WebDriver server at ' + url));
+[firefox #2]           ^
+[firefox #2] Error: Timed out waiting for the WebDriver server at http://127.0.0.1:50845/hub
+[firefox #2]     at Error (native)
+[firefox #2]     at onResponse (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/http/util.js:89:11)
+[firefox #2]     at /usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/http/util.js:44:21
+[firefox #2]     at /usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/webdriver/http/http.js:140:5
+[firefox #2]     at ClientRequest.<anonymous> (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/http/index.js:174:7)
+[firefox #2]     at emitOne (events.js:77:13)
+[firefox #2]     at ClientRequest.emit (events.js:169:7)
+[firefox #2]     at Socket.socketErrorListener (_http_client.js:256:9)
+[firefox #2]     at emitOne (events.js:77:13)
+[firefox #2]     at Socket.emit (events.js:169:7)
+[firefox #2] From: Task: WebDriver.createSession()
+[firefox #2]     at Function.webdriver.WebDriver.acquireSession_ (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/webdriver/webdriver.js:157:22)
+[firefox #2]     at Function.webdriver.WebDriver.createSession (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/webdriver/webdriver.js:131:30)
+[firefox #2]     at new Driver (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/firefox/index.js:278:36)
+[firefox #2]     at [object Object].DirectDriverProvider.getNewDriver (/usr/local/lib/node_modules/protractor/lib/driverProviders/direct.js:74:16)
+[firefox #2]     at [object Object].Runner.createBrowser (/usr/local/lib/node_modules/protractor/lib/runner.js:190:37)
+[firefox #2]     at /usr/local/lib/node_modules/protractor/lib/runner.js:280:21
+[firefox #2]     at _fulfilled (/usr/local/lib/node_modules/protractor/node_modules/q/q.js:834:54)
+[firefox #2]     at self.promiseDispatch.done (/usr/local/lib/node_modules/protractor/node_modules/q/q.js:863:30)
+[firefox #2]     at Promise.promise.promiseDispatch (/usr/local/lib/node_modules/protractor/node_modules/q/q.js:796:13)
+[firefox #2]     at /usr/local/lib/node_modules/protractor/node_modules/q/q.js:556:49
+
+[launcher] Runner process exited unexpectedly with error code: 1
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #1 passed
+[launcher] firefox #2 failed with exit code: 1
+[launcher] overall: 1 process(es) failed to complete
+Closing report
+[launcher] Process exited with error code 100

--- a/test/support/fixtures/sharded-error-test-output.txt
+++ b/test/support/fixtures/sharded-error-test-output.txt
@@ -1,0 +1,86 @@
+[launcher] Running 2 instances of WebDriver
+.
+------------------------------------
+[chrome #1-1] PID: 9865
+[chrome #1-1] Specs: /Users/ntomlin/workspace/protractor-flake/test/support/a-good-test.test.js
+[chrome #1-1] 
+[chrome #1-1] Using ChromeDriver directly...
+[chrome #1-1] [32m.[0m
+[chrome #1-1] 
+[chrome #1-1] Finished in 0.041 seconds
+[chrome #1-1] [32m1 test, 1 assertion, 0 failures
+[0m[chrome #1-1] 
+
+[launcher] 2 instance(s) of WebDriver still running
+F
+------------------------------------
+[chrome #1-0] PID: 9864
+[chrome #1-0] Specs: /Users/ntomlin/workspace/protractor-flake/test/support/a-flakey.test.js
+[chrome #1-0] 
+[chrome #1-0] Using ChromeDriver directly...
+[chrome #1-0] [31mF[0m
+[chrome #1-0] 
+[chrome #1-0] Failures:
+[chrome #1-0] 
+[chrome #1-0]   1) a flakey integration test fails, in a horribly consistent manner
+[chrome #1-0]    Message:
+[chrome #1-0]      [31mExpected false to be truthy.[0m
+[chrome #1-0]    Stacktrace:
+[chrome #1-0]      Error: Failed expectation
+[chrome #1-0]     at [object Object].<anonymous> (/Users/ntomlin/workspace/protractor-flake/test/support/a-flakey.test.js:9:39)
+[chrome #1-0] 
+[chrome #1-0] Finished in 1.021 seconds
+[chrome #1-0] [31m1 test, 1 assertion, 1 failure
+[0m[chrome #1-0] 
+
+[launcher] 1 instance(s) of WebDriver still running
+F
+------------------------------------
+[chrome #1-43] PID: 7548
+[chrome #1-43] Specs: /Users/ntomlin/workspace/protractor-flake/test/support/another-flakey.test.js
+[chrome #1-43]
+[chrome #1-43] Using the selenium server at http://10.10.100.34:4444/wd/hub
+[chrome #1-43] Spec started
+[chrome #1-43] Started
+[chrome #1-43] Executing on selenium node: [http://10.10.100.103:5556]
+[chrome #1-43]
+[chrome #1-43]   The Patient dialog
+[chrome #1-43]
+[chrome #1-43]     should respond to selecting a conversation by
+[chrome #1-43]       ✓ displaying a conversation
+[chrome #1-43] .      ✗ focusing the message
+[chrome #1-43]         - Failed: Session [41abf706-688f-44be-ac49-9c4c051ab53b] was terminated due to SO_TIMEOUT
+[chrome #1-43]             at new bot.Error (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/atoms/error.js:108:18)
+[chrome #1-43]             at Object.bot.response.checkResponse (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/atoms/response.js:109:9)
+[chrome #1-43]             at /usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/webdriver/webdriver.js:379:20
+[chrome #1-43]             at [object Object].promise.Promise.goog.defineClass.invokeCallback_ (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/goog/../webdriver/promise.js:1337:14)
+[chrome #1-43]             at [object Object].promise.ControlFlow.goog.defineClass.goog.defineClass.abort_.error.executeNext_.execute_ (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/goog/../webdriver/promise.js:2776:14)
+[chrome #1-43]             at [object Object].promise.ControlFlow.goog.defineClass.goog.defineClass.abort_.error.executeNext_ (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/goog/../webdriver/promise.js:2758:21)
+[chrome #1-43]             at goog.async.run.processWorkQueue (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/goog/async/run.js:124:15)
+[chrome #1-43]             at process._tickCallback (node.js:379:9)
+[chrome #1-43]         From: Task: Run beforeEach in control flow
+[chrome #1-43]             at Object.<anonymous> (/usr/local/lib/node_modules/protractor/node_modules/jasminewd2/index.js:81:14)
+[chrome #1-43]         From asynchronous test:
+[chrome #1-43]         Error
+[chrome #1-43]             at Suite.<anonymous> (/Users/ntomlin/workspace/protractor-flake/test/support/a-flakey.test.js:9:39)
+[chrome #1-43] F
+[chrome #1-43] /usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/atoms/error.js:108
+[chrome #1-43]   var template = new Error(this.message);
+[chrome #1-43]                  ^
+[chrome #1-43] UnknownError: Session [41abf706-688f-44be-ac49-9c4c051ab53b] was terminated due to SO_TIMEOUT
+[chrome #1-43]     at new bot.Error (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/atoms/error.js:108:18)
+[chrome #1-43]     at Object.bot.response.checkResponse (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/atoms/response.js:109:9)
+[chrome #1-43]     at /usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/webdriver/webdriver.js:379:20
+[chrome #1-43]     at [object Object].promise.Promise.goog.defineClass.invokeCallback_ (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/goog/../webdriver/promise.js:1337:14)
+[chrome #1-43]     at [object Object].promise.ControlFlow.goog.defineClass.goog.defineClass.abort_.error.executeNext_.execute_ (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/goog/../webdriver/promise.js:2776:14)
+[chrome #1-43]     at [object Object].promise.ControlFlow.goog.defineClass.goog.defineClass.abort_.error.executeNext_ (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/goog/../webdriver/promise.js:2758:21)
+[chrome #1-43]     at goog.async.run.processWorkQueue (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/goog/async/run.js:124:15)
+[chrome #1-43]     at process._tickCallback (node.js:379:9)
+
+[launcher] Runner process exited unexpectedly with error code: 1
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #1-1 passed
+[launcher] chrome #1-0 failed 1 test(s)
+[launcher] chrome #1-2 failed 1 test(s)
+[launcher] overall: 2 failed spec(s)
+[launcher] Process exited with error code 1


### PR DESCRIPTION
hey,

Now as long as the output contains sharding + Spec: description, protractor-flake will also re-run the test files that went into error state.

Problem:
In the situation that:
- Test A has a failed expectation
- Test B went into error state
- Test C passed
  Only Test A will be re-run. And if the test passes, the whole run will have passed (marked unstable)
  But Test B has never been run, it has been skipped.

Fix:
Now in the situation that Specs: is described, and you use sharing, all the test files that did NOT return an OK signal, will be rerun - instead of the tests that returned with a failure.
