### PR TITLE
Update standard.js

### DIFF
--- a/src/parsers/standard.js
+++ b/src/parsers/standard.js
@@ -4,7 +4,7 @@ export default {
   parse (output) {
     let failedSpecs = new Set()
     let match = null
-    let FAILED_LINES = /at (?:\[object Object\]|Object)\.<anonymous> \((([A-Za-z]:\\)?.*?):.*\)/g
+    let FAILED_LINES = /at (?:\[object Object\]|Object)\.<anonymous> \((([A-Za-z]:\\)?.*?_spec.js):.*\)/g
     while (match = FAILED_LINES.exec(output)) { // eslint-disable-line no-cond-assign
       // windows output includes stack traces from
       // webdriver so we filter those out here


### PR DESCRIPTION
fixed regex, for preventing non spec files to be run as spec
