### PR TITLE
Fix/cucumber multicapabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 test/integration/support/times-flaked
 dist
 !dist/.gitkeep
+.idea

--- a/README.md
+++ b/README.md
@@ -60,6 +60,30 @@ Protractor flake defaults to using the `standard` parser, which will typically p
 
 You can override this with the `parser` option, specifying one of the [built in parsers](src/parsers/index.js).
 
+#### Cucumberjs parser
+Cucumberjs > v0.9.0 has a different logging and also a differen way in returning the path of the runned specs. (See example [logging](test/unit/support/fixtures/cucumberjs)). Based on the way the capability in Protractor has been configured the `Specs:` are printed. See the table below for the results.
+
+| Capability | shardTestFiles | Feature | Failures | Specs printed |
+| :--------: | :------------: | :-----: | :------: | :-----------: |
+|  single    |      true      |    1    |   true   |     false     |
+|  single    |     false      |    1    |   true   |     false     |
+|  single    |      true      |    1    |  false   |     false     |
+|  single    |     false      |    1    |  false   |     false     |
+|  single    |      true      |   >1    |   true   |    **true**   |
+|  single    |     false      |   >1    |   true   |     false     |
+|  single    |      true      |   >1    |  false   |    **true**   |
+|  single    |     false      |   >1    |  false   |     false     |
+|  multi     |      true      |    1    |   true   |    **true**   |
+|  multi     |     false      |    1    |   true   |    **true**   |
+|  multi     |      true      |    1    |  false   |    **true**   |
+|  multi     |     false      |    1    |  false   |    **true**   |
+|  multi     |      true      |   >1    |   true   |    **true**   |
+|  multi     |     false      |   >1    |   true   |   **false**   |
+|  multi     |      true      |   >1    |  false   |    **true**   |
+|  multi     |     false      |   >1    |  false   |     false     |
+
+When no `Specs:` are printed in the logging Protractor will run the Protractor command again which means that all the specs are run on all the instances (also the succeeded specs).
+
 # Caveats
 
 This has not yet been tested with Protractor + Mocha. It _should_ function similarly. Please update with an issue or PR if this is not the case.

--- a/README.md
+++ b/README.md
@@ -60,29 +60,8 @@ Protractor flake defaults to using the `standard` parser, which will typically p
 
 You can override this with the `parser` option, specifying one of the [built in parsers](src/parsers/index.js).
 
-#### Cucumberjs parser
-Cucumberjs > v0.9.0 has a different logging and also a differen way in returning the path of the runned specs. (See example [logging](test/unit/support/fixtures/cucumberjs)). Based on the way the capability in Protractor has been configured the `Specs:` are printed. See the table below for the results.
-
-| Capability | shardTestFiles | Feature | Failures | Specs printed |
-| :--------: | :------------: | :-----: | :------: | :-----------: |
-|  single    |      true      |    1    |   true   |     false     |
-|  single    |     false      |    1    |   true   |     false     |
-|  single    |      true      |    1    |  false   |     false     |
-|  single    |     false      |    1    |  false   |     false     |
-|  single    |      true      |   >1    |   true   |    **true**   |
-|  single    |     false      |   >1    |   true   |     false     |
-|  single    |      true      |   >1    |  false   |    **true**   |
-|  single    |     false      |   >1    |  false   |     false     |
-|  multi     |      true      |    1    |   true   |    **true**   |
-|  multi     |     false      |    1    |   true   |    **true**   |
-|  multi     |      true      |    1    |  false   |    **true**   |
-|  multi     |     false      |    1    |  false   |    **true**   |
-|  multi     |      true      |   >1    |   true   |    **true**   |
-|  multi     |     false      |   >1    |   true   |   **false**   |
-|  multi     |      true      |   >1    |  false   |    **true**   |
-|  multi     |     false      |   >1    |  false   |     false     |
-
-When no `Specs:` are printed in the logging Protractor will run the Protractor command again which means that all the specs are run on all the instances (also the succeeded specs).
+#### Parser documentation
+- [cucmber](docs/cucumber.md)
 
 # Caveats
 

--- a/docs/cucumber.md
+++ b/docs/cucumber.md
@@ -1,5 +1,5 @@
 
-# Cucumberjs parser  
+# Cucumberjs parser
 
 ## cucumber
 > This parser only works with `cucumberjs` version < v0.9.0
@@ -57,3 +57,21 @@ multiCapabilities = [
 |  multi     |     false      |   >1    |  false   |     false     |
 
 When no `Specs:` are printed in the logging Protractor will run the Protractor command again which means that all the specs are run on **ALL** the instances (also the succeeded specs).
+  
+### Always print specs
+There is a way to always print `Specs:`. This can be done with the following hook, see [cucumberjs](https://github.com/cucumber/cucumber-js) for more hook info:
+
+```
+var afterHook = function () {
+  this.After(function (scenario, callback) {
+        if (scenario.isFailed()) {
+            console.log('Specs:', scenario.getUri());
+        }
+        callback();
+  });
+};
+
+module.exports = afterHook;
+```
+
+This will always print the `Specs:` in the testoutput. The parser will filter double specs. 

--- a/docs/cucumber.md
+++ b/docs/cucumber.md
@@ -1,0 +1,59 @@
+
+# Cucumberjs parser  
+
+## cucumber
+> This parser only works with `cucumberjs` version < v0.9.0
+
+The `cucumber` parser will search the testoutput for this piece of text `/path/to/your/featurefile/flakey.feature:4 # Scenario: Flakey scenario`. This is the line that says that a scenario in a featurefile failed.
+The `/path/to/your/featurefile/flakey.feature` piece will be stripped out and passed to `protractor-flake` to rerun the file(s) for the amount of retries that have been given.
+
+## cucumberMulti
+> This parser is based on `cucumberjs` > v0.9.0. These versions have a different logging and also a different way in returning the path of the runned specs. (See example [logging](test/unit/support/fixtures/cucumberjs/)).
+
+> **This parser can parse testoutput from `capabilities` and `multiCapabilities`**
+
+The `cucumberMulti` parser will search the testoutput for the text combination `Failures:`and `Specs: /path/to/your/featurefile/flakey.feature`. 
+The parser needs to search for both pieces of text because succeeded specs are also being logged.
+The `/path/to/your/featurefile/flakey.feature` piece will be stripped out and passed to `protractor-flake` to rerun the file(s) for the amount of retries that have been given.
+
+Based on the way the capability in Protractor has been configured the `Specs:` are printed. See the table below for the results.	
+
+```
+// Single
+capabilities: {
+    browserName: 'chrome',
+    shardTestFiles: true
+}
+// Multi
+multiCapabilities = [
+    {
+        browserName: 'chrome',
+        shardTestFiles: true
+    },
+    {
+        browserName: 'firefox',
+        shardTestFiles: true
+    }
+]
+```
+
+| Capability | shardTestFiles | Feature | Failures | Specs printed |
+| :--------: | :------------: | :-----: | :------: | :-----------: |
+|  single    |      true      |    1    |   true   |     false     |
+|  single    |     false      |    1    |   true   |     false     |
+|  single    |      true      |    1    |  false   |     false     |
+|  single    |     false      |    1    |  false   |     false     |
+|  single    |      true      |   >1    |   true   |    **TRUE**   |
+|  single    |     false      |   >1    |   true   |     false     |
+|  single    |      true      |   >1    |  false   |    **TRUE**   |
+|  single    |     false      |   >1    |  false   |     false     |
+|  multi     |      true      |    1    |   true   |    **TRUE**   |
+|  multi     |     false      |    1    |   true   |    **TRUE**   |
+|  multi     |      true      |    1    |  false   |    **TRUE**   |
+|  multi     |     false      |    1    |  false   |    **TRUE**   |
+|  multi     |      true      |   >1    |   true   |    **TRUE**   |
+|  multi     |     false      |   >1    |   true   |   **FALSE**   |
+|  multi     |      true      |   >1    |  false   |    **TRUE**   |
+|  multi     |     false      |   >1    |  false   |     false     |
+
+When no `Specs:` are printed in the logging Protractor will run the Protractor command again which means that all the specs are run on **ALL** the instances (also the succeeded specs).

--- a/src/index.js
+++ b/src/index.js
@@ -22,16 +22,18 @@ export default function (options = {}, callback = function noop () {}) {
     if (status === 0) {
       callback(status)
     } else {
-      let failedSpecs = parser.parse(output)
       if (++testAttempt <= parsedOptions.maxAttempts) {
-        log('info', `Using ${parser.name} to parse output\n`)
+        log('info', `\nUsing ${parser.name} to parse output\n`)
+        let failedSpecs = parser.parse(output)
+
         log('info', `Re-running tests: test attempt ${testAttempt}\n`)
-        log('info', 'Re-running the following test files:\n')
-        log('info', failedSpecs.join('\n') + '\n')
+        if (failedSpecs.length === 0) {
+          log('info', '\nTests failed but no specs were found. All specs will be run again.\n\n')
+        } else {
+          log('info', 'Re-running the following test files:\n')
+          log('info', failedSpecs.join('\n') + '\n')
+        }
         return startProtractor(failedSpecs)
-      }
-      if (failedSpecs.length === 0) {
-        log('info', '\nTests failed but no specs were found. All specs have been run again.\n\n')
       }
 
       callback(status, output)

--- a/src/index.js
+++ b/src/index.js
@@ -22,14 +22,16 @@ export default function (options = {}, callback = function noop () {}) {
     if (status === 0) {
       callback(status)
     } else {
+      let failedSpecs = parser.parse(output)
       if (++testAttempt <= parsedOptions.maxAttempts) {
         log('info', `Using ${parser.name} to parse output\n`)
-        let failedSpecs = parser.parse(output)
-
         log('info', `Re-running tests: test attempt ${testAttempt}\n`)
         log('info', 'Re-running the following test files:\n')
         log('info', failedSpecs.join('\n') + '\n')
         return startProtractor(failedSpecs)
+      }
+      if (failedSpecs.length === 0) {
+        log('info', '\nTests failed but no specs were found. All specs have been run again.\n\n')
       }
 
       callback(status, output)

--- a/src/parsers/cucumber.multi.js
+++ b/src/parsers/cucumber.multi.js
@@ -1,0 +1,29 @@
+export default {
+  name: 'cucumberMulti',
+  parse (output) {
+    let match = null
+    let failedSpecs = []
+    let testsOutput = output.split('------------------------------------')
+    let RESULT_FAIL = /(.*?) Failures:.*/g
+    let SPECFILE_REG = /(.*?) Specs:\s(.*\.feature)/g
+    testsOutput.forEach(function (test) {
+      let specfile
+      let result = 'passed'
+      // only check specs when RESULT_FAIL, ` Specs: ` is always printed when at least multiple features on 1 instance
+      // are run with `shardTestFiles: true`
+      if (RESULT_FAIL.exec(test)) { // eslint-disable-line no-cond-assign
+        while (match = SPECFILE_REG.exec(test)) { // eslint-disable-line no-cond-assign
+          specfile = match[2]
+          result = 'failed'
+        }
+      }
+      if (specfile && result === 'failed') {
+        if (!/node_modules/.test(specfile)) {
+          failedSpecs.push(specfile)
+        }
+      }
+    })
+    // Remove double values
+    return [...new Set(failedSpecs)]
+  }
+}

--- a/src/parsers/cucumber.multi.js
+++ b/src/parsers/cucumber.multi.js
@@ -4,7 +4,7 @@ export default {
     let match = null
     let failedSpecs = []
     let testsOutput = output.split('------------------------------------')
-    let RESULT_FAIL = /(.*?) Failures:.*/g
+    let RESULT_FAIL = /Failures:.*/g
     let SPECFILE_REG = /Specs:\s(.*\.feature)/g
     testsOutput.forEach(function (test) {
       let specfile
@@ -12,6 +12,7 @@ export default {
       // only check specs when RESULT_FAIL, ` Specs: ` is always printed when at least multiple features on 1 instance
       // are run with `shardTestFiles: true`
       if (RESULT_FAIL.exec(test)) { // eslint-disable-line no-cond-assign
+        console.log('Failed')
         while (match = SPECFILE_REG.exec(test)) { // eslint-disable-line no-cond-assign
           specfile = match[1]
           result = 'failed'

--- a/src/parsers/cucumber.multi.js
+++ b/src/parsers/cucumber.multi.js
@@ -5,7 +5,7 @@ export default {
     let failedSpecs = []
     let testsOutput = output.split('------------------------------------')
     let RESULT_FAIL = /(.*?) Failures:.*/g
-    let SPECFILE_REG = /(.*?) Specs:\s(.*\.feature)/g
+    let SPECFILE_REG = /Specs:\s(.*\.feature)/g
     testsOutput.forEach(function (test) {
       let specfile
       let result = 'passed'
@@ -13,7 +13,7 @@ export default {
       // are run with `shardTestFiles: true`
       if (RESULT_FAIL.exec(test)) { // eslint-disable-line no-cond-assign
         while (match = SPECFILE_REG.exec(test)) { // eslint-disable-line no-cond-assign
-          specfile = match[2]
+          specfile = match[1]
           result = 'failed'
         }
       }

--- a/src/parsers/cucumber.multi.js
+++ b/src/parsers/cucumber.multi.js
@@ -12,7 +12,6 @@ export default {
       // only check specs when RESULT_FAIL, ` Specs: ` is always printed when at least multiple features on 1 instance
       // are run with `shardTestFiles: true`
       if (RESULT_FAIL.exec(test)) { // eslint-disable-line no-cond-assign
-        console.log('Failed')
         while (match = SPECFILE_REG.exec(test)) { // eslint-disable-line no-cond-assign
           specfile = match[1]
           result = 'failed'

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -1,8 +1,9 @@
 import cucumber from './cucumber'
+import cucumberMulti from './cucumber.multi'
 import multi from './multi'
 import standard from './standard'
 
-let all = { cucumber, multi, standard }
+let all = { cucumber, cucumberMulti, multi, standard }
 
 function getParser (name) {
   if (name && all[name]) {

--- a/test/unit/parsers/cucumber.multi.test.js
+++ b/test/unit/parsers/cucumber.multi.test.js
@@ -2,50 +2,6 @@ import readFixture from '../support/read-fixture'
 import multiParser from '../../../src/parsers/cucumber.multi'
 
 describe('cucumberMultiParser', () => {
-  /**
-   * How it works:
-   * Single:
-   * - 1 webdriver instance + 1 feature + error + shardTestFiles
-   *    No Specs !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   * - 1 webdriver instance + 1 feature + error + !shardTestFiles
-   *    No Specs !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   * - 1 webdriver instance + 1 feature + success + shardTestFiles
-   *    No Specs !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   * - 1 webdriver instance + 1 feature + success + !shardTestFiles
-   *    No Specs !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   * - 1 webdriver instance + 2 features + error + shardTestFiles
-   *    SPECS ###################################################
-   * - 1 webdriver instance + 2 features + error + !shardTestFiles
-   *    No Specs !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   * - 1 webdriver instance + 2 features + success + shardTestFiles
-   *    SPECS ###################################################
-   * - 1 webdriver instance + 2 features + success + !shardTestFiles
-   *    No Specs !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   *
-   * Conclusion:
-   *
-   *
-   * Multi:
-   * - 2 webdriver instances + 1 feature + error + !shardTestFiles
-   *    SPECS for both ############################################
-   * - 2 webdriver instances + 1 feature + error + shardTestFiles
-   *    SPECS for both ############################################
-   * - 2 webdriver instances + 1 feature + success + !shardTestFiles
-   *    SPECS for both ############################################
-   * - 2 webdriver instances + 1 feature + success + shardTestFiles
-   *    SPECS for both ############################################
-   * - 2 webdriver instances + 2 features + error + !shardTestFiles
-   *    NO specs for both !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   * - 2 webdriver instances + 2 features + error + shardTestFiles
-   *    SPECS for both ############################################
-   * - 2 webdriver instances + 2 features + success + !shardTestFiles
-   *    NO specs for both !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   * - 2 webdriver instances + 2 features + success + shardTestFiles
-   *    SPECS for both ############################################
-   *
-   * Conclusion:
-   * SHARED needs to be true for multiple. Then it's always printed. First check on `Failures:`, then on `Specs:`   *
-   */
   describe('#parse', () => {
     it('properly handles error output in multicapabilities tests with a feature', function () {
       let output = readFixture('cucumberjs/cucumberjs-multi-output-feature-failure.txt')

--- a/test/unit/parsers/cucumber.multi.test.js
+++ b/test/unit/parsers/cucumber.multi.test.js
@@ -1,0 +1,105 @@
+import readFixture from '../support/read-fixture'
+import multiParser from '../../../src/parsers/cucumber.multi'
+
+describe('cucumberMultiParser', () => {
+  /**
+   * How it works:
+   * Single:
+   * - 1 webdriver instance + 1 feature + error + shardTestFiles
+   *    No Specs !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   * - 1 webdriver instance + 1 feature + error + !shardTestFiles
+   *    No Specs !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   * - 1 webdriver instance + 1 feature + success + shardTestFiles
+   *    No Specs !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   * - 1 webdriver instance + 1 feature + success + !shardTestFiles
+   *    No Specs !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   * - 1 webdriver instance + 2 features + error + shardTestFiles
+   *    SPECS ###################################################
+   * - 1 webdriver instance + 2 features + error + !shardTestFiles
+   *    No Specs !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   * - 1 webdriver instance + 2 features + success + shardTestFiles
+   *    SPECS ###################################################
+   * - 1 webdriver instance + 2 features + success + !shardTestFiles
+   *    No Specs !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   *
+   * Conclusion:
+   *
+   *
+   * Multi:
+   * - 2 webdriver instances + 1 feature + error + !shardTestFiles
+   *    SPECS for both ############################################
+   * - 2 webdriver instances + 1 feature + error + shardTestFiles
+   *    SPECS for both ############################################
+   * - 2 webdriver instances + 1 feature + success + !shardTestFiles
+   *    SPECS for both ############################################
+   * - 2 webdriver instances + 1 feature + success + shardTestFiles
+   *    SPECS for both ############################################
+   * - 2 webdriver instances + 2 features + error + !shardTestFiles
+   *    NO specs for both !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   * - 2 webdriver instances + 2 features + error + shardTestFiles
+   *    SPECS for both ############################################
+   * - 2 webdriver instances + 2 features + success + !shardTestFiles
+   *    NO specs for both !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   * - 2 webdriver instances + 2 features + success + shardTestFiles
+   *    SPECS for both ############################################
+   *
+   * Conclusion:
+   * SHARED needs to be true for multiple. Then it's always printed. First check on `Failures:`, then on `Specs:`   *
+   */
+  describe('#parse', () => {
+    it('properly handles error output in multicapabilities tests with a feature', function () {
+      let output = readFixture('cucumberjs/cucumberjs-multi-output-feature-failure.txt')
+
+      expect(multiParser.parse(output)).to.eql([
+        '/Users/wswebcreation/test/e2e/features/functional/flakey.feature'
+      ])
+    })
+
+    it('properly handles error output in sharded multicapabilities tests with a feature', function () {
+      let output = readFixture('cucumberjs/cucumberjs-multi-output-shared-feature-failure.txt')
+
+      expect(multiParser.parse(output)).to.eql([
+        '/Users/wswebcreation/test/e2e/features/functional/flakey.feature'
+      ])
+    })
+
+    it('returns an empty array if cucumberjs output has no matches for a multicapabilities tests with a feature', function () {
+      let output = readFixture('cucumberjs/cucumberjs-multi-output-feature-success.txt')
+
+      expect(multiParser.parse(output)).to.eql([])
+    })
+
+    it('returns an empty array if cucumberjs output has no matches for a sharded multicapabilities tests with a feature', function () {
+      let output = readFixture('cucumberjs/cucumberjs-multi-output-shared-feature-success.txt')
+
+      expect(multiParser.parse(output)).to.eql([])
+    })
+
+    it('can\'t handles error output in multicapabilities tests with features', function () {
+      let output = readFixture('cucumberjs/cucumberjs-multi-output-features-failures.txt')
+
+      expect(multiParser.parse(output)).to.eql([])
+    })
+
+    it('properly handles error output in sharded multicapabilities tests with features and double failures', function () {
+      let output = readFixture('cucumberjs/cucumberjs-multi-output-shared-features-failures.txt')
+
+      expect(multiParser.parse(output)).to.eql([
+        '/Users/wswebcreation/test/e2e/features/functional/another.flakey.feature',
+        '/Users/wswebcreation/test/e2e/features/functional/flakey.feature'
+      ])
+    })
+
+    it('returns an empty array if cucumberjs output has no matches for a multicapabilities tests with features', function () {
+      let output = readFixture('cucumberjs/cucumberjs-multi-output-features-success.txt')
+
+      expect(multiParser.parse(output)).to.eql([])
+    })
+
+    it('returns an empty array if cucumberjs output has no matches for a sharded multicapabilities tests with features', function () {
+      let output = readFixture('cucumberjs/cucumberjs-multi-output-shared-features-success.txt')
+
+      expect(multiParser.parse(output)).to.eql([])
+    })
+  })
+})

--- a/test/unit/support/fixtures/cucumberjs/cucumberjs-multi-output-feature-failure.txt
+++ b/test/unit/support/fixtures/cucumberjs/cucumberjs-multi-output-feature-failure.txt
@@ -1,0 +1,52 @@
+[launcher] Running 2 instances of WebDriver
+.
+------------------------------------
+[chrome #01] PID: 33160
+[chrome #01] Specs: /Users/wswebcreation/test/e2e/features/functional/flakey.feature
+[chrome #01] 
+[chrome #01] Using the selenium server at http://localhost:4444/wd/hub
+[chrome #01] Feature: Flake unit tests
+[chrome #01] 
+[chrome #01]   Scenario: A flakey scenario
+[chrome #01]     Then a flakey integration test fails for firefox
+[chrome #01] 
+[chrome #01] 1 scenario (1 passed)
+[chrome #01] 1 step (1 passed)
+[chrome #01] 0m00.007s
+
+[launcher] 1 instance(s) of WebDriver still running
+F
+------------------------------------
+[firefox #11] PID: 33161
+[firefox #11] Specs: /Users/wswebcreation/test/e2e/features/functional/flakey.feature
+[firefox #11] 
+[firefox #11] Using the selenium server at http://localhost:4444/wd/hub
+[firefox #11] Feature: Flake unit tests
+[firefox #11] 
+[firefox #11]   Scenario: A flakey scenario
+[firefox #11]     Then a flakey integration test fails for firefox
+[firefox #11] 
+[firefox #11] Failures:
+[firefox #11] 
+[firefox #11] 1) Scenario: A flakey scenario - test/e2e/features/functional/flakey.feature:6
+[firefox #11]    Then a flakey integration test fails for firefox - test/e2e/features/functional/flakey.feature:7
+[firefox #11]    Step Definition: test/e2e/step_definitions/functional.steps.js:56
+[firefox #11]    Message:
+[firefox #11]      AssertionError: expected true to equal false
+[firefox #11]          at World.<anonymous> (/Users/wswebcreation/test/e2e/step_definitions/functional.steps.js:59:32)
+[firefox #11]          at doNTCallback0 (node.js:428:9)
+[firefox #11]          at process._tickCallback (node.js:357:13)
+[firefox #11] 
+[firefox #11] 1 scenario (1 failed)
+[firefox #11] 1 step (1 failed)
+[firefox #11] 0m00.131s
+
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #01 passed
+[launcher] firefox #11 failed 1 test(s)
+[launcher] overall: 1 failed spec(s)
+[launcher] Process exited with error code 1
+>> 
+Warning: Tests failed, protractor exited with code: 1 Use --force to continue.
+
+Aborted due to warnings.

--- a/test/unit/support/fixtures/cucumberjs/cucumberjs-multi-output-feature-success.txt
+++ b/test/unit/support/fixtures/cucumberjs/cucumberjs-multi-output-feature-success.txt
@@ -1,0 +1,37 @@
+[launcher] Running 2 instances of WebDriver
+.
+------------------------------------
+[chrome #01] PID: 33789
+[chrome #01] Specs: /Users/wswebcreation/e2e/features/functional/success.feature
+[chrome #01]
+[chrome #01] Using the selenium server at http://localhost:4444/wd/hub
+[chrome #01] Feature: Working feature
+[chrome #01]
+[chrome #01]   Scenario: A working scenario
+[chrome #01]     Then an integration test succeeds in a consistent manner
+[chrome #01]
+[chrome #01] 1 scenario (1 passed)
+[chrome #01] 1 step (1 passed)
+[chrome #01] 0m00.006s
+
+[launcher] 1 instance(s) of WebDriver still running
+.
+------------------------------------
+[firefox #11] PID: 33790
+[firefox #11] Specs: /Users/wswebcreation/e2e/features/functional/success.feature
+[firefox #11]
+[firefox #11] Using the selenium server at http://localhost:4444/wd/hub
+[firefox #11] Feature: Flake unit tests
+[firefox #11]
+[firefox #11]   Scenario: A flakey scenario
+[firefox #11]     Then a flakey integration test fails, in a horribly consistent manner
+[firefox #11]
+[firefox #11] 1 scenario (1 passed)
+[firefox #11] 1 step (1 passed)
+[firefox #11] 0m00.005s
+
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #01 passed
+[launcher] firefox #11 passed
+
+Done.

--- a/test/unit/support/fixtures/cucumberjs/cucumberjs-multi-output-features-failures.txt
+++ b/test/unit/support/fixtures/cucumberjs/cucumberjs-multi-output-features-failures.txt
@@ -1,0 +1,78 @@
+[launcher] Running 2 instances of WebDriver
+F.
+------------------------------------
+[chrome #01] PID: 33973
+[chrome #01] Using the selenium server at http://localhost:4444/wd/hub
+[chrome #01] Feature: More flake unit tests
+[chrome #01] 
+[chrome #01]   Scenario: Another flakey scenario
+[chrome #01]     Then another flakey integration test fails, in a horribly consistent manner
+[chrome #01] 
+[chrome #01] Feature: Flake unit tests
+[chrome #01] 
+[chrome #01]   Scenario: A flakey scenario
+[chrome #01]     Then a flakey integration test fails, in a horribly consistent manner
+[chrome #01] 
+[chrome #01] Failures:
+[chrome #01] 
+[chrome #01] 1) Scenario: Another flakey scenario - test/e2e/features/functional/another.flakey.feature:6
+[chrome #01]    Step: Then another flakey integration test fails, in a horribly consistent manner - test/e2e/features/functional/another.flakey.feature:7
+[chrome #01]    Step Definition: test/e2e/step_definitions/functional.steps.js:62
+[chrome #01]    Message:
+[chrome #01]      AssertionError: expected true to equal false
+[chrome #01]          at World.<anonymous> (/Users/wswebcreation/test/e2e/step_definitions/functional.steps.js:63:32)
+[chrome #01]          at doNTCallback0 (node.js:428:9)
+[chrome #01]          at process._tickCallback (node.js:357:13)
+[chrome #01] 
+[chrome #01] 2 scenarios (1 failed, 1 passed)
+[chrome #01] 2 steps (1 failed, 1 passed)
+[chrome #01] 0m00.360s
+
+[launcher] 1 instance(s) of WebDriver still running
+FF
+------------------------------------
+[firefox #11] PID: 33974
+[firefox #11] Using the selenium server at http://localhost:4444/wd/hub
+[firefox #11] Feature: More flake unit tests
+[firefox #11] 
+[firefox #11]   Scenario: Another flakey scenario
+[firefox #11]     Then another flakey integration test fails, in a horribly consistent manner
+[firefox #11] 
+[firefox #11] Feature: Flake unit tests
+[firefox #11] 
+[firefox #11]   Scenario: A flakey scenario
+[firefox #11]     Then a flakey integration test fails, in a horribly consistent manner
+[firefox #11] 
+[firefox #11] Failures:
+[firefox #11] 
+[firefox #11] 1) Scenario: Another flakey scenario - test/e2e/features/functional/another.flakey.feature:6
+[firefox #11]    Step: Then another flakey integration test fails, in a horribly consistent manner - test/e2e/features/functional/another.flakey.feature:7
+[firefox #11]    Step Definition: test/e2e/step_definitions/functional.steps.js:62
+[firefox #11]    Message:
+[firefox #11]      AssertionError: expected true to equal false
+[firefox #11]          at World.<anonymous> (/Users/wswebcreation/test/e2e/step_definitions/functional.steps.js:63:32)
+[firefox #11]          at doNTCallback0 (node.js:428:9)
+[firefox #11]          at process._tickCallback (node.js:357:13)
+[firefox #11] 
+[firefox #11] 2) Scenario: A flakey scenario - test/e2e/features/functional/flakey.feature:6
+[firefox #11]    Step: Then a flakey integration test fails, in a horribly consistent manner - test/e2e/features/functional/flakey.feature:7
+[firefox #11]    Step Definition: test/e2e/step_definitions/functional.steps.js:56
+[firefox #11]    Message:
+[firefox #11]      AssertionError: expected true to equal false
+[firefox #11]          at World.<anonymous> (/Users/wswebcreation/test/e2e/step_definitions/functional.steps.js:59:32)
+[firefox #11]          at doNTCallback0 (node.js:428:9)
+[firefox #11]          at process._tickCallback (node.js:357:13)
+[firefox #11] 
+[firefox #11] 2 scenarios (2 failed)
+[firefox #11] 2 steps (2 failed)
+[firefox #11] 0m00.202s
+
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #01 failed 1 test(s)
+[launcher] firefox #11 failed 2 test(s)
+[launcher] overall: 3 failed spec(s)
+[launcher] Process exited with error code 1
+>> 
+Warning: Tests failed, protractor exited with code: 1 Use --force to continue.
+
+Aborted due to warnings.

--- a/test/unit/support/fixtures/cucumberjs/cucumberjs-multi-output-features-success.txt
+++ b/test/unit/support/fixtures/cucumberjs/cucumberjs-multi-output-features-success.txt
@@ -1,0 +1,43 @@
+[launcher] Running 2 instances of WebDriver
+..
+------------------------------------
+[chrome #01] PID: 34165
+[chrome #01] Using the selenium server at http://localhost:4444/wd/hub
+[chrome #01] Feature: More flake unit tests
+[chrome #01]
+[chrome #01]   Scenario: Another flakey scenario
+[chrome #01]     Then another flakey integration test fails, in a horribly consistent manner
+[chrome #01]
+[chrome #01] Feature: Flake unit tests
+[chrome #01]
+[chrome #01]   Scenario: A flakey scenario
+[chrome #01]     Then a flakey integration test fails, in a horribly consistent manner
+[chrome #01]
+[chrome #01] 2 scenarios (2 passed)
+[chrome #01] 2 steps (2 passed)
+[chrome #01] 0m00.007s
+
+[launcher] 1 instance(s) of WebDriver still running
+..
+------------------------------------
+[firefox #11] PID: 34166
+[firefox #11] Using the selenium server at http://localhost:4444/wd/hub
+[firefox #11] Feature: More flake unit tests
+[firefox #11]
+[firefox #11]   Scenario: Another flakey scenario
+[firefox #11]     Then another flakey integration test fails, in a horribly consistent manner
+[firefox #11]
+[firefox #11] Feature: Flake unit tests
+[firefox #11]
+[firefox #11]   Scenario: A flakey scenario
+[firefox #11]     Then a flakey integration test fails, in a horribly consistent manner
+[firefox #11]
+[firefox #11] 2 scenarios (2 passed)
+[firefox #11] 2 steps (2 passed)
+[firefox #11] 0m00.006s
+
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #01 passed
+[launcher] firefox #11 passed
+
+Done.

--- a/test/unit/support/fixtures/cucumberjs/cucumberjs-multi-output-shared-feature-failure.txt
+++ b/test/unit/support/fixtures/cucumberjs/cucumberjs-multi-output-shared-feature-failure.txt
@@ -1,0 +1,52 @@
+[launcher] Running 2 instances of WebDriver
+.
+------------------------------------
+[chrome #01] PID: 33652
+[chrome #01] Specs: /Users/wswebcreation/e2e/features/functional/flakey.feature
+[chrome #01] 
+[chrome #01] Using the selenium server at http://localhost:4444/wd/hub
+[chrome #01] Feature: Flake unit tests
+[chrome #01] 
+[chrome #01]   Scenario: A flakey scenario
+[chrome #01]     Then a flakey integration test fails for firefox
+[chrome #01] 
+[chrome #01] 1 scenario (1 passed)
+[chrome #01] 1 step (1 passed)
+[chrome #01] 0m00.007s
+
+[launcher] 1 instance(s) of WebDriver still running
+F
+------------------------------------
+[firefox #11] PID: 33653
+[firefox #11] Specs: /Users/wswebcreation/test/e2e/features/functional/flakey.feature
+[firefox #11] 
+[firefox #11] Using the selenium server at http://localhost:4444/wd/hub
+[firefox #11] Feature: Flake unit tests
+[firefox #11] 
+[firefox #11]   Scenario: A flakey scenario
+[firefox #11]     Then a flakey integration test fails for firefox
+[firefox #11] 
+[firefox #11] Failures:
+[firefox #11] 
+[firefox #11] 1) Scenario: A flakey scenario - test/e2e/features/functional/flakey.feature:6
+[firefox #11]    Step: Then a flakey integration test fails for firefox - test/e2e/features/functional/flakey.feature:7
+[firefox #11]    Step Definition: test/e2e/step_definitions/functional.steps.js:56
+[firefox #11]    Message:
+[firefox #11]      AssertionError: expected true to equal false
+[firefox #11]          at World.<anonymous> (/Users/wswebcreation/e2e/step_definitions/functional.steps.js:59:32)
+[firefox #11]          at doNTCallback0 (node.js:428:9)
+[firefox #11]          at process._tickCallback (node.js:357:13)
+[firefox #11] 
+[firefox #11] 1 scenario (1 failed)
+[firefox #11] 1 step (1 failed)
+[firefox #11] 0m00.116s
+
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #01 passed
+[launcher] firefox #11 failed 1 test(s)
+[launcher] overall: 1 failed spec(s)
+[launcher] Process exited with error code 1
+>> 
+Warning: Tests failed, protractor exited with code: 1 Use --force to continue.
+
+Aborted due to warnings.

--- a/test/unit/support/fixtures/cucumberjs/cucumberjs-multi-output-shared-feature-success.txt
+++ b/test/unit/support/fixtures/cucumberjs/cucumberjs-multi-output-shared-feature-success.txt
@@ -1,0 +1,37 @@
+[launcher] Running 2 instances of WebDriver
+.
+------------------------------------
+[chrome #01] PID: 33886
+[chrome #01] Specs: /Users/wswebcreation/e2e/features/functional/success.feature
+[chrome #01] 
+[chrome #01] Using the selenium server at http://localhost:4444/wd/hub
+[chrome #01] Feature: Working feature
+[chrome #01] 
+[chrome #01]   Scenario: A working scenario
+[chrome #01]     Then a integration test succeeds in a consistent manner
+[chrome #01] 
+[chrome #01] 1 scenario (1 passed)
+[chrome #01] 1 step (1 passed)
+[chrome #01] 0m00.006s
+
+[launcher] 1 instance(s) of WebDriver still running
+.
+------------------------------------
+[firefox #11] PID: 33887
+[firefox #11] Specs: /Users/wswebcreation/e2e/features/functional/success.feature
+[firefox #11]
+[firefox #11] Using the selenium server at http://localhost:4444/wd/hub
+[firefox #11] Feature: Flake unit tests
+[firefox #11]
+[firefox #11]   Scenario: A flakey scenario
+[firefox #11]     Then a flakey integration test fails, in a horribly consistent manner
+[firefox #11]
+[firefox #11] 1 scenario (1 passed)
+[firefox #11] 1 step (1 passed)
+[firefox #11] 0m00.005s
+
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #01 passed
+[launcher] firefox #11 passed
+
+Done.

--- a/test/unit/support/fixtures/cucumberjs/cucumberjs-multi-output-shared-features-failures.txt
+++ b/test/unit/support/fixtures/cucumberjs/cucumberjs-multi-output-shared-features-failures.txt
@@ -1,0 +1,108 @@
+[launcher] Running 2 instances of WebDriver
+F
+------------------------------------
+[chrome #01-0] PID: 34060
+[chrome #01-0] Specs: /Users/wswebcreation/test/e2e/features/functional/another.flakey.feature
+[chrome #01-0] 
+[chrome #01-0] Using the selenium server at http://localhost:4444/wd/hub
+[chrome #01-0] Feature: More flake unit tests
+[chrome #01-0] 
+[chrome #01-0]   Scenario: Another flakey scenario
+[chrome #01-0]     Then another flakey integration test fails, in a horribly consistent manner
+[chrome #01-0] 
+[chrome #01-0] Failures:
+[chrome #01-0] 
+[chrome #01-0] 1) Scenario: Another flakey scenario - test/e2e/features/functional/another.flakey.feature:6
+[chrome #01-0]    Step: Then another flakey integration test fails, in a horribly consistent manner - test/e2e/features/functional/another.flakey.feature:7
+[chrome #01-0]    Step Definition: test/e2e/step_definitions/functional.steps.js:62
+[chrome #01-0]    Message:
+[chrome #01-0]      AssertionError: expected true to equal false
+[chrome #01-0]          at World.<anonymous> (/Users/wswebcreation/test/e2e/step_definitions/functional.steps.js:63:32)
+[chrome #01-0]          at doNTCallback0 (node.js:428:9)
+[chrome #01-0]          at process._tickCallback (node.js:357:13)
+[chrome #01-0] 
+[chrome #01-0] 1 scenario (1 failed)
+[chrome #01-0] 1 step (1 failed)
+[chrome #01-0] 0m00.370s
+
+[launcher] 2 instance(s) of WebDriver still running
+F
+------------------------------------
+[firefox #11-0] PID: 34061
+[firefox #11-0] Specs: /Users/wswebcreation/test/e2e/features/functional/another.flakey.feature
+[firefox #11-0] 
+[firefox #11-0] Using the selenium server at http://localhost:4444/wd/hub
+[firefox #11-0] Feature: More flake unit tests
+[firefox #11-0] 
+[firefox #11-0]   Scenario: Another flakey scenario
+[firefox #11-0]     Then another flakey integration test fails, in a horribly consistent manner
+[firefox #11-0] 
+[firefox #11-0] Failures:
+[firefox #11-0] 
+[firefox #11-0] 1) Scenario: Another flakey scenario - test/e2e/features/functional/another.flakey.feature:6
+[firefox #11-0]    Step: Then another flakey integration test fails, in a horribly consistent manner - test/e2e/features/functional/another.flakey.feature:7
+[firefox #11-0]    Step Definition: test/e2e/step_definitions/functional.steps.js:62
+[firefox #11-0]    Message:
+[firefox #11-0]      AssertionError: expected true to equal false
+[firefox #11-0]          at World.<anonymous> (/Users/wswebcreation/test/e2e/step_definitions/functional.steps.js:63:32)
+[firefox #11-0]          at doNTCallback0 (node.js:428:9)
+[firefox #11-0]          at process._tickCallback (node.js:357:13)
+[firefox #11-0] 
+[firefox #11-0] 1 scenario (1 failed)
+[firefox #11-0] 1 step (1 failed)
+[firefox #11-0] 0m00.130s
+
+[launcher] 2 instance(s) of WebDriver still running
+.
+------------------------------------
+[chrome #01-1] PID: 34073
+[chrome #01-1] Specs: /Users/wswebcreation/test/e2e/features/functional/flakey.feature
+[chrome #01-1] 
+[chrome #01-1] Using the selenium server at http://localhost:4444/wd/hub
+[chrome #01-1] Feature: Flake unit tests
+[chrome #01-1] 
+[chrome #01-1]   Scenario: A flakey scenario
+[chrome #01-1]     Then a flakey integration test fails for firefox
+[chrome #01-1] 
+[chrome #01-1] 1 scenario (1 passed)
+[chrome #01-1] 1 step (1 passed)
+[chrome #01-1] 0m00.006s
+
+[launcher] 1 instance(s) of WebDriver still running
+F
+------------------------------------
+[firefox #11-1] PID: 34086
+[firefox #11-1] Specs: /Users/wswebcreation/test/e2e/features/functional/flakey.feature
+[firefox #11-1] 
+[firefox #11-1] Using the selenium server at http://localhost:4444/wd/hub
+[firefox #11-1] Feature: Flake unit tests
+[firefox #11-1] 
+[firefox #11-1]   Scenario: A flakey scenario
+[firefox #11-1]     Then a flakey integration test fails for firefox
+[firefox #11-1] 
+[firefox #11-1] Failures:
+[firefox #11-1] 
+[firefox #11-1] 1) Scenario: A flakey scenario - test/e2e/features/functional/flakey.feature:6
+[firefox #11-1]    Step: Then a flakey integration test fails for firefox - test/e2e/features/functional/flakey.feature:7
+[firefox #11-1]    Step Definition: test/e2e/step_definitions/functional.steps.js:56
+[firefox #11-1]    Message:
+[firefox #11-1]      AssertionError: expected true to equal false
+[firefox #11-1]          at World.<anonymous> (/Users/wswebcreation/test/e2e/step_definitions/functional.steps.js:59:32)
+[firefox #11-1]          at doNTCallback0 (node.js:428:9)
+[firefox #11-1]          at process._tickCallback (node.js:357:13)
+[firefox #11-1] 
+[firefox #11-1] 1 scenario (1 failed)
+[firefox #11-1] 1 step (1 failed)
+[firefox #11-1] 0m00.116s
+
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #01-0 failed 1 test(s)
+[launcher] firefox #11-0 failed 1 test(s)
+[launcher] chrome #01-1 passed
+[launcher] firefox #11-1 failed 1 test(s)
+[launcher] overall: 3 failed spec(s)
+[launcher] Process exited with error code 1
+>> 
+Warning: Tests failed, protractor exited with code: 1 Use --force to continue.
+
+Aborted due to warnings.

--- a/test/unit/support/fixtures/cucumberjs/cucumberjs-multi-output-shared-features-success.txt
+++ b/test/unit/support/fixtures/cucumberjs/cucumberjs-multi-output-shared-features-success.txt
@@ -1,0 +1,71 @@
+[launcher] Running 2 instances of WebDriver
+.
+------------------------------------
+[chrome #01-0] PID: 34243
+[chrome #01-0] Specs: /Users/wswebcreation/Rabobank/Online/cqc/test/e2e/features/functional/another.success.feature
+[chrome #01-0]
+[chrome #01-0] Using the selenium server at http://localhost:4444/wd/hub
+[chrome #01-0] Feature: More successful unit tests
+[chrome #01-0]
+[chrome #01-0]   Scenario: Another successful scenario
+[chrome #01-0]     Then another integration test succeeds in a consistent manner
+[chrome #01-0]
+[chrome #01-0] 1 scenario (1 passed)
+[chrome #01-0] 1 step (1 passed)
+[chrome #01-0] 0m00.006s
+
+[launcher] 2 instance(s) of WebDriver still running
+.
+------------------------------------
+[firefox #11-0] PID: 34244
+[firefox #11-0] Specs: /Users/wswebcreation/Rabobank/Online/cqc/test/e2e/features/functional/another.success.feature
+[firefox #11-0]
+[firefox #11-0] Using the selenium server at http://localhost:4444/wd/hub
+[firefox #11-0] Feature: More successful unit tests
+[firefox #11-0]
+[firefox #11-0]   Scenario: Another successful scenario
+[firefox #11-0]     Then another integration test succeeds in a consistent manner
+[firefox #11-0]
+[firefox #11-0] 1 scenario (1 passed)
+[firefox #11-0] 1 step (1 passed)
+[firefox #11-0] 0m00.006s
+
+[launcher] 2 instance(s) of WebDriver still running
+.
+------------------------------------
+[chrome #01-1] PID: 34259
+[chrome #01-1] Specs: /Users/wswebcreation/Rabobank/Online/cqc/test/e2e/features/functional/flakey.feature
+[chrome #01-1]
+[chrome #01-1] Using the selenium server at http://localhost:4444/wd/hub
+[chrome #01-1] Feature: Successful unit tests
+[chrome #01-1]
+[chrome #01-1]   Scenario: A successful scenario
+[chrome #01-1]     Then an integration test succeeds in a consistent manner
+[chrome #01-1]
+[chrome #01-1] 1 scenario (1 passed)
+[chrome #01-1] 1 step (1 passed)
+[chrome #01-1] 0m00.006s
+
+[launcher] 1 instance(s) of WebDriver still running
+.
+------------------------------------
+[firefox #11-1] PID: 34270
+[firefox #11-1] Specs: /Users/wswebcreation/Rabobank/Online/cqc/test/e2e/features/functional/flakey.feature
+[firefox #11-1]
+[firefox #11-1] Using the selenium server at http://localhost:4444/wd/hub
+[firefox #11-1] Feature: Successful unit tests
+[firefox #11-1]
+[firefox #11-1]   Scenario: A successful scenario
+[firefox #11-1]     Then an integration test succeeds in a consistent manner
+[firefox #11-1]
+[firefox #11-1] 1 scenario (1 passed)
+[firefox #11-1] 1 step (1 passed)
+[firefox #11-1] 0m00.005s
+
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #01-0 passed
+[launcher] firefox #11-0 passed
+[launcher] chrome #01-1 passed
+[launcher] firefox #11-1 passed
+
+Done.

--- a/test/unit/support/fixtures/cucumberjs/cucumberjs-single-output-feature-failure.txt
+++ b/test/unit/support/fixtures/cucumberjs/cucumberjs-single-output-feature-failure.txt
@@ -1,0 +1,29 @@
+Using the selenium server at http://localhost:4444/wd/hub
+[launcher] Running 1 instances of WebDriver
+Feature: Flake unit tests
+
+  Scenario: A flakey scenario
+    Then a flakey integration test fails, in a horribly consistent manner
+
+Failures:
+
+1) Scenario: A flakey scenario - test/e2e/features/functional/flakey.feature:6
+   Step: Then a flakey integration test fails, in a horribly consistent manner - test/e2e/features/functional/flakey.feature:7
+   Step Definition: test/e2e/step_definitions/functional.steps.js:56
+   Message:
+     AssertionError: expected true to equal false
+         at World.<anonymous> (/Users/wswebcreation/e2e/step_definitions/functional.steps.js:59:32)
+         at doNTCallback0 (node.js:428:9)
+         at process._tickCallback (node.js:357:13)
+
+1 scenario (1 failed)
+1 step (1 failed)
+0m00.185s
+protractor-utils.hooks: DEVICETYPE IS NOT PROVIDED AND SET TO `undefined`
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] firefox #01 failed 1 test(s)
+[launcher] overall: 1 failed spec(s)
+[launcher] Process exited with error code 1
+Warning: Tests failed, protractor exited with code: 1 Use --force to continue.
+
+Aborted due to warnings.

--- a/test/unit/support/fixtures/cucumberjs/cucumberjs-single-output-feature-sharded-failure.txt
+++ b/test/unit/support/fixtures/cucumberjs/cucumberjs-single-output-feature-sharded-failure.txt
@@ -1,0 +1,29 @@
+Using the selenium server at http://localhost:4444/wd/hub
+[launcher] Running 1 instances of WebDriver
+Feature: Flake unit tests
+
+  Scenario: A flakey scenario
+    Then a flakey integration test fails, in a horribly consistent manner
+
+Failures:
+
+1) Scenario: A flakey scenario - test/e2e/features/functional/flakey.feature:6
+   Step: Then a flakey integration test fails, in a horribly consistent manner - test/e2e/features/functional/flakey.feature:7
+   Step Definition: test/e2e/step_definitions/functional.steps.js:56
+   Message:
+     AssertionError: expected true to equal false
+         at World.<anonymous> (/Users/wswebcreation/e2e/step_definitions/functional.steps.js:59:32)
+         at doNTCallback0 (node.js:428:9)
+         at process._tickCallback (node.js:357:13)
+
+1 scenario (1 failed)
+1 step (1 failed)
+0m00.127s
+protractor-utils.hooks: DEVICETYPE IS NOT PROVIDED AND SET TO `undefined`
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] firefox #01 failed 1 test(s)
+[launcher] overall: 1 failed spec(s)
+[launcher] Process exited with error code 1
+Warning: Tests failed, protractor exited with code: 1 Use --force to continue.
+
+Aborted due to warnings.

--- a/test/unit/support/fixtures/cucumberjs/cucumberjs-single-output-feature-success.txt
+++ b/test/unit/support/fixtures/cucumberjs/cucumberjs-single-output-feature-success.txt
@@ -1,0 +1,14 @@
+Using the selenium server at http://localhost:4444/wd/hub
+[launcher] Running 1 instances of WebDriver
+Feature: Flake unit tests
+
+  Scenario: A flakey scenario
+    Then a flakey integration test fails, in a horribly consistent manner
+
+1 scenario (1 passed)
+1 step (1 passed)
+0m00.005s
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #01 passed
+
+Done.

--- a/test/unit/support/fixtures/cucumberjs/cucumberjs-single-output-features-failure.txt
+++ b/test/unit/support/fixtures/cucumberjs/cucumberjs-single-output-features-failure.txt
@@ -1,0 +1,34 @@
+Using the selenium server at http://localhost:4444/wd/hub
+[launcher] Running 1 instances of WebDriver
+Feature: More flake unit tests
+
+  Scenario: Another flakey scenario
+    Then another flakey integration test fails, in a horribly consistent manner
+
+Feature: Flake unit tests
+
+  Scenario: A flakey scenario
+    Then a flakey integration test fails, in a horribly consistent manner
+
+Failures:
+
+1) Scenario: Another flakey scenario - test/e2e/features/functional/another.flakey.feature:6
+   Step: Then another flakey integration test fails, in a horribly consistent manner - test/e2e/features/functional/another.flakey.feature:7
+   Step Definition: test/e2e/step_definitions/functional.steps.js:62
+   Message:
+     AssertionError: expected true to equal false
+         at World.<anonymous> (/Users/wswebcreation/Rabobank/Online/cqc/test/e2e/step_definitions/functional.steps.js:63:32)
+         at doNTCallback0 (node.js:428:9)
+         at process._tickCallback (node.js:357:13)
+
+2 scenarios (1 failed, 1 passed)
+2 steps (1 failed, 1 passed)
+0m00.379s
+protractor-utils.hooks: DEVICETYPE IS NOT PROVIDED AND SET TO `undefined`
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #01 failed 1 test(s)
+[launcher] overall: 1 failed spec(s)
+[launcher] Process exited with error code 1
+Warning: Tests failed, protractor exited with code: 1 Use --force to continue.
+
+Aborted due to warnings.

--- a/test/unit/support/fixtures/cucumberjs/cucumberjs-single-output-features-sharded-success.txt
+++ b/test/unit/support/fixtures/cucumberjs/cucumberjs-single-output-features-sharded-success.txt
@@ -1,0 +1,37 @@
+[launcher] Running 1 instances of WebDriver
+.
+------------------------------------
+[chrome #01-0] PID: 33449
+[chrome #01-0] Specs: /Users/wswebcreation/e2e/features/functional/another.flakey.feature
+[chrome #01-0] 
+[chrome #01-0] Using the selenium server at http://localhost:4444/wd/hub
+[chrome #01-0] Feature: More flake unit tests
+[chrome #01-0] 
+[chrome #01-0]   Scenario: Another flakey scenario
+[chrome #01-0]     Then another flakey integration test fails, in a horribly consistent manner
+[chrome #01-0] 
+[chrome #01-0] 1 scenario (1 passed)
+[chrome #01-0] 1 step (1 passed)
+[chrome #01-0] 0m00.005s
+
+[launcher] 1 instance(s) of WebDriver still running
+.
+------------------------------------
+[chrome #01-1] PID: 33460
+[chrome #01-1] Specs: /Users/wswebcreation/e2e/features/functional/flakey.feature
+[chrome #01-1] 
+[chrome #01-1] Using the selenium server at http://localhost:4444/wd/hub
+[chrome #01-1] Feature: Flake unit tests
+[chrome #01-1] 
+[chrome #01-1]   Scenario: A flakey scenario
+[chrome #01-1]     Then a flakey integration test fails, in a horribly consistent manner
+[chrome #01-1] 
+[chrome #01-1] 1 scenario (1 passed)
+[chrome #01-1] 1 step (1 passed)
+[chrome #01-1] 0m00.005s
+
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #01-0 passed
+[launcher] chrome #01-1 passed
+
+Done.

--- a/test/unit/support/fixtures/cucumberjs/cucumberjs-single-output-features-success.txt
+++ b/test/unit/support/fixtures/cucumberjs/cucumberjs-single-output-features-success.txt
@@ -1,0 +1,18 @@
+[launcher] Running 1 instances of WebDriver
+Feature: More flake unit tests
+
+  Scenario: Another flakey scenario
+    Then another flakey integration test fails, in a horribly consistent manner
+
+Feature: Flake unit tests
+
+  Scenario: A flakey scenario
+    Then a flakey integration test fails, in a horribly consistent manner
+
+2 scenarios (2 passed)
+2 steps (2 passed)
+0m00.006s
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #01 passed
+
+Done.

--- a/test/unit/support/fixtures/cucumberjs/cucumberjs-single-output-sharded-features-failure.txt
+++ b/test/unit/support/fixtures/cucumberjs/cucumberjs-single-output-sharded-features-failure.txt
@@ -1,0 +1,52 @@
+[launcher] Running 1 instances of WebDriver
+F
+------------------------------------
+[chrome #01-0] PID: 33345
+[chrome #01-0] Specs: /Users/wswebcreation/test/e2e/features/functional/another.flakey.feature
+[chrome #01-0] 
+[chrome #01-0] Using the selenium server at http://localhost:4444/wd/hub
+[chrome #01-0] Feature: More flake unit tests
+[chrome #01-0] 
+[chrome #01-0]   Scenario: Another flakey scenario
+[chrome #01-0]     Then another flakey integration test fails, in a horribly consistent manner
+[chrome #01-0] 
+[chrome #01-0] Failures:
+[chrome #01-0] 
+[chrome #01-0] 1) Scenario: Another flakey scenario - test/e2e/features/functional/another.flakey.feature:6
+[chrome #01-0]    Step: Then another flakey integration test fails, in a horribly consistent manner - test/e2e/features/functional/another.flakey.feature:7
+[chrome #01-0]    Step Definition: test/e2e/step_definitions/functional.steps.js:62
+[chrome #01-0]    Message:
+[chrome #01-0]      AssertionError: expected true to equal false
+[chrome #01-0]          at World.<anonymous> (/Users/wswebcreation/test/e2e/step_definitions/functional.steps.js:63:32)
+[chrome #01-0]          at doNTCallback0 (node.js:428:9)
+[chrome #01-0]          at process._tickCallback (node.js:357:13)
+[chrome #01-0] 
+[chrome #01-0] 1 scenario (1 failed)
+[chrome #01-0] 1 step (1 failed)
+[chrome #01-0] 0m00.348s
+
+[launcher] 1 instance(s) of WebDriver still running
+.
+------------------------------------
+[chrome #01-1] PID: 33356
+[chrome #01-1] Specs: /Users/wswebcreation/test/e2e/features/functional/flakey.feature
+[chrome #01-1] 
+[chrome #01-1] Using the selenium server at http://localhost:4444/wd/hub
+[chrome #01-1] Feature: Flake unit tests
+[chrome #01-1] 
+[chrome #01-1]   Scenario: A flakey scenario
+[chrome #01-1]     Then a flakey integration test fails, in a horribly consistent manner
+[chrome #01-1] 
+[chrome #01-1] 1 scenario (1 passed)
+[chrome #01-1] 1 step (1 passed)
+[chrome #01-1] 0m00.006s
+
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #01-0 failed 1 test(s)
+[launcher] chrome #01-1 passed
+[launcher] overall: 1 failed spec(s)
+[launcher] Process exited with error code 1
+>> 
+Warning: Tests failed, protractor exited with code: 1 Use --force to continue.
+
+Aborted due to warnings.

--- a/test/unit/support/fixtures/cucumberjs/cucumberjs-single-output-shared-feature-succes.txt
+++ b/test/unit/support/fixtures/cucumberjs/cucumberjs-single-output-shared-feature-succes.txt
@@ -1,0 +1,14 @@
+Using the selenium server at http://localhost:4444/wd/hub
+[launcher] Running 1 instances of WebDriver
+Feature: Flake unit tests
+
+  Scenario: A flakey scenario
+    Then a flakey integration test fails, in a horribly consistent manner
+
+1 scenario (1 passed)
+1 step (1 passed)
+0m00.005s
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #01 passed
+
+Done.


### PR DESCRIPTION
This PR makes it able to only rerun failed test of CucumberJS tests that are run with Protractor `multiCapabilities`. See the README for more info on when and how
