### PR TITLE
Feature/pass args to conf on retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ protractor-flake
 
 # Full options
 # protractor-flake <protractor-flake-options> -- <options to be passed to protractor>
-protractor-flake --protractor-path=/path/to/protractor --parser standard --node-bin node --max-attempts=3 -- path/to/protractor.conf.js
+protractor-flake --protractor-path=/path/to/protractor --parser standard --node-bin node --max-attempts=3 --retryArgs= -- path/to/protractor.conf.js
 ```
 
 Protractor flake expects `protractor` to be on $PATH by default, but you can use the `--protractor-path` argument to point to the protractor executable.
@@ -47,7 +47,8 @@ protractorFlake({
   // expects node to be in path
   // set this to wherever the node bin is located
   nodeBin: 'node',
-  protractorArgs: []
+  protractorArgs: [],
+  retryArgs: []
 }, function (status, output) {
   process.exit(status);
 });
@@ -64,6 +65,11 @@ You can override this with the `parser` option, specifying one of the [built in 
 - Mocha (TODO)
 - Jasmine (TODO)
 - [cucumber](docs/cucumber.md)
+
+### Additional Flags
+
+#### retryArgs
+Allows the user to pass arguments to protractor when re-running failed specs. `Accepts an array of strings or comma delimited string`
 
 # Caveats
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,8 @@ const DEFAULT_OPTIONS = {
   nodeBin: 'node',
   maxAttempts: 3,
   protractorArgs: DEFAULT_PROTRACTOR_ARGS,
-  parser: 'standard'
+  parser: 'standard',
+  retryArgs: ''
 }
 
 function filterArgs (protractorArgs) {
@@ -67,7 +68,12 @@ export default function (options = {}, callback = function noop () {}) {
 
     if (specFiles.length) {
       protractorArgs = filterArgs(protractorArgs)
-      protractorArgs.push('--specs', specFiles.join(','))
+      protractorArgs.push('--specs', specFiles.join(','));
+
+      //Add parameters to set/override values in protractor.conf.js file in event of spec failure
+      if (parsedOptions.retryArgs.length){
+        protractorArgs = protractorArgs.concat(parsedOptions.retryArgs.split(','));
+      }
     }
 
     let protractor = spawn(

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const DEFAULT_OPTIONS = {
   maxAttempts: 3,
   protractorArgs: DEFAULT_PROTRACTOR_ARGS,
   parser: 'standard',
-  retryArgs: ''
+  retryArgs: []
 }
 
 function filterArgs (protractorArgs) {
@@ -71,8 +71,14 @@ export default function (options = {}, callback = function noop () {}) {
       protractorArgs.push('--specs', specFiles.join(','));
 
       //Add parameters to set/override values in protractor.conf.js file in event of spec failure
-      if (parsedOptions.retryArgs.length){
-        protractorArgs = protractorArgs.concat(parsedOptions.retryArgs.split(','));
+      if (parsedOptions.retryArgs){
+        let args = [];
+        if (Array.isArray(parsedOptions.retryArgs)){
+          args = parsedOptions.retryArgs;
+        } else if (typeof parsedOptions.retryArgs === 'string' || parsedOptions.retryArgs instanceof String) {
+          args = parsedOptions.retryArgs.split(',')
+        }
+        protractorArgs = protractorArgs.concat(args);
       }
     }
 

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -189,4 +189,55 @@ describe('Protractor Flake', () => {
       expect(spawnStub).to.have.been.calledWithMatch('node', [pathToProtractor()], { cwd: './' })
     })
   })
+
+  context('retryArgs', () => {
+
+    it('does not use retryArgs with only 1 attempt', function () {
+      protractorFlake({
+        maxAttempts: 1,
+        retryArgs: '--shouldNotBePassed=true'
+      });
+
+      spawnStub.dataCallback(failedShardedTestOutput);
+      spawnStub.endCallback(1);
+
+      expect(spawnStub).to.have.been.calledWith('node', [
+        pathToProtractor()
+      ]);
+    });
+
+    it('passes retryArgs with 2 or more attempts as a string', function () {
+      protractorFlake({
+        maxAttempts: 2,
+        retryArgs: '--shouldBePassed=true,--shouldNotBePassed=false'
+      });
+
+      spawnStub.dataCallback(failedShardedTestOutput);
+      spawnStub.endCallback(1);
+
+      expect(spawnStub).to.have.been.calledWith('node', [
+        pathToProtractor(),
+        '--specs', '/tests/a-flakey.test.js,/tests/another-flakey.test.js',
+        '--shouldBePassed=true', '--shouldNotBePassed=false'
+      ]);
+    });
+
+    it('passes retryArgs with 2 or more attempts as an array', function () {
+      protractorFlake({
+        maxAttempts: 3,
+        retryArgs: ['--shouldNotBePassed=false', '--shouldBePassed=true']
+      });
+
+      spawnStub.dataCallback(failedShardedTestOutput);
+      spawnStub.endCallback(1);
+
+      expect(spawnStub).to.have.been.calledWith('node', [
+        pathToProtractor(),
+        '--specs', '/tests/a-flakey.test.js,/tests/another-flakey.test.js',
+        '--shouldNotBePassed=false',
+        '--shouldBePassed=true'
+      ]);
+    });
+
+  });
 })


### PR DESCRIPTION
Hi, I created this fork to allow user to pass parameters specifically when re-running failed specs. I have ran into scenarios where I want to override certain settings when re-running failed specs in my protractor.conf.js file and this change allows that plus a wide range of other scenarios.

The reason why I am allowing both a string and an array is because it's easier to create an array to be passed to protractor flake programmatically, but when using command-line arguments, its easier to use and comma delimited string.