### PR TITLE
User supplied parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,14 @@ Parsers should be defined as an object with a `parse` method (and optionally a `
 ```
 module.exports = {
   parse (protractorTestOutput) {
-    let specFiles = []
+    let failedSpecs = new Set()
     // ... analyze protractor test output
     // ... and add to specFiles
+    failedSpecs.add('path/to/failed/specfile')
 
     // specFiles to be re-run by protractor-flake
     // if an empty array is returned, all specs will be re-run
-    return specFiles;
+    return [...failedSpecs]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,27 @@ protractorFlake({
 
 Protractor flake defaults to using the `standard` parser, which will typically pick up failures run from non-sharded/multi-capability test runs using Jasmine 1 + 2 and Mocha.
 
-You can override this with the `parser` option, specifying one of the [built in parsers](src/parsers/index.js).
+There are a few other ways that you can customize your parsing:
+
+- overriding this with the `parser` option, specifying one of the [built in parsers](src/parsers/index.js).
+- providing a path to a module (e.g. `/my/module.js` or `./module.js`) that exports a [parser](test/unit/support/custom-parser.js)
+- a parser (if used programatically)
+
+Parsers should be defined as an object with a `parse` method (and optionally a `name` property):
+
+```
+module.exports = {
+  parse (protractorTestOutput) {
+    let specFiles = []
+    // ... analyze protractor test output
+    // ... and add to specFiles
+
+    // specFiles to be re-run by protractor-flake
+    // if an empty array is returned, all specs will be re-run
+    return specFiles;
+  }
+}
+```
 
 #### Parser documentation
 - Mocha (TODO)

--- a/src/parse-options.js
+++ b/src/parse-options.js
@@ -1,0 +1,26 @@
+import {resolve} from 'path'
+
+const DEFAULT_PROTRACTOR_ARGS = []
+const DEFAULT_OPTIONS = {
+  nodeBin: 'node',
+  maxAttempts: 3,
+  protractorArgs: DEFAULT_PROTRACTOR_ARGS,
+  parser: 'standard'
+}
+
+function parseOptions (providedOptions) {
+  let options = Object.assign({}, DEFAULT_OPTIONS, providedOptions)
+
+  if (options.protractorPath) {
+    options.protractorPath = resolve(options.protractorPath)
+  } else {
+    // '.../node_modules/protractor/lib/protractor.js'
+    let protractorMainPath = require.resolve('protractor')
+    // '.../node_modules/protractor/bin/protractor'
+    options.protractorPath = resolve(protractorMainPath, '../../bin/protractor')
+  }
+
+  return options
+}
+
+export default parseOptions

--- a/src/parse-options.js
+++ b/src/parse-options.js
@@ -1,10 +1,12 @@
 import {resolve} from 'path'
 
-const DEFAULT_PROTRACTOR_ARGS = []
 const DEFAULT_OPTIONS = {
   nodeBin: 'node',
   maxAttempts: 3,
-  protractorArgs: DEFAULT_PROTRACTOR_ARGS,
+  protractorArgs: [],
+  // the name of one of the included parsers
+  // a function to be used as a parser
+  // or the path to a node module that exports a parser
   parser: 'standard'
 }
 

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -14,7 +14,7 @@ function handleObject (parserObject) {
   return parserObject
 }
 
-function handlePah (parserPath) {
+function handlePath (parserPath) {
   try {
     let customParserPath = require.resolve(parserPath)
     return require(customParserPath)
@@ -37,7 +37,7 @@ function getParser (parser = '') {
   }
 
   if (extname(parser)) {
-    return handlePah(parser)
+    return handlePath(parser)
   }
 
   return handleFlakeParser(parser)

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -1,16 +1,46 @@
 import cucumber from './cucumber'
 import cucumberMulti from './cucumber.multi'
+import { extname } from 'path'
 import multi from './multi'
 import standard from './standard'
 
 let all = { cucumber, cucumberMulti, multi, standard }
 
-function getParser (name) {
-  if (name && all[name]) {
-    return all[name]
-  } else {
-    throw new Error(`Invalid Parser Specified: ${name}`)
+function handleObject (parserObject) {
+  if (typeof parserObject.parse !== 'function') {
+    throw new Error(`Invalid Parser Object specified. Your parser must define a \`parse\` method`)
   }
+
+  return parserObject
+}
+
+function handlePah (parserPath) {
+  try {
+    let customParserPath = require.resolve(parserPath)
+    return require(customParserPath)
+  } catch (e) {
+    throw new Error(`Invalid Custom Parser Path Specified: ${parserPath}`)
+  }
+}
+
+function handleFlakeParser (parserName) {
+  if (all[parserName]) {
+    return all[parserName]
+  } else {
+    throw new Error(`Invalid Parser Specified: ${parserName}`)
+  }
+}
+
+function getParser (parser = '') {
+  if (parser.hasOwnProperty('parse')) {
+    return handleObject(parser)
+  }
+
+  if (extname(parser)) {
+    return handlePah(parser)
+  }
+
+  return handleFlakeParser(parser)
 }
 
 export default { all, getParser }

--- a/test/integration/bin.js
+++ b/test/integration/bin.js
@@ -60,6 +60,19 @@ describe('Protractor Flake Executable', function () {
     })
   })
 
+  it.only('integration: requires and uses a custom parser module if a "path" is provided', (done) => {
+    // this is a parser that returns 'passing-test.js'
+    // without it the tests will fail since we are using the 'always-fail' spec.
+    // not the most direct way of testing this functionality...
+    const customParserPath = resolve(__dirname, 'support/custom-parser-that-will-pass.js')
+    let proc = spawnFlake(['--max-attempts', '2', '--parser', customParserPath, '--', configPath('always-fail')])
+
+    proc.on('close', (status) => {
+      expect(status).to.equal(0)
+      done()
+    })
+  })
+
   it('integration: exits with error if invalid parser is specified', (done) => {
     let output = ''
     let proc = spawnFlake(['--max-attempts', '3', '--parser', 'foo', '--', configPath('sharded')])

--- a/test/integration/support/custom-parser-that-will-pass.js
+++ b/test/integration/support/custom-parser-that-will-pass.js
@@ -1,0 +1,6 @@
+module.exports = {
+  name: 'MyCustomParser',
+  parse (outputFromProtractorTests) {
+    return ['test/integration/support/passing-test.js']
+  }
+}

--- a/test/unit/parsers/index.test.js
+++ b/test/unit/parsers/index.test.js
@@ -1,3 +1,5 @@
+import { resolve } from 'path'
+import customParser from '../support/custom-parser'
 import parsers from '../../../src/parsers'
 import standardParser from '../../../src/parsers/standard'
 import cucumberParser from '../../../src/parsers/cucumber'
@@ -44,6 +46,37 @@ describe('parsers', () => {
       it('returns a cucumber parser if specified', () => {
         let returnedParser = parsers.getParser('cucumber')
         expect(returnedParser).to.eq(cucumberParser)
+      })
+    })
+
+    context('with a "path" provided', () => {
+      it('requires a module at the given path', () => {
+        let customParserPath = resolve(__dirname, '../support/custom-parser.js')
+        let returnedParser = parsers.getParser(customParserPath)
+
+        expect(returnedParser).to.eq(customParser)
+      })
+
+      it('throws an invalid parser error if module does not exist', () => {
+        let customParserPath = resolve(__dirname, '../support/nonexistantparser.js')
+
+        expect(() => {
+          parsers.getParser(customParserPath)
+        }).to.throw(new RegExp(`Invalid Custom Parser Path Specified: ${customParserPath}`))
+      })
+    })
+
+    context('with a parser object provided', () => {
+      it('returns the object', () => {
+        expect(parsers.getParser(customParser)).to.eq(customParser)
+      })
+
+      it('throws an error if object does not supply a parse function', () => {
+        expect(() => {
+          parsers.getParser({
+            parse: 'not a function dawg'
+          })
+        }).to.throw(`Invalid Parser Object specified. Your parser must define a \`parse\` method`)
       })
     })
   })

--- a/test/unit/support/custom-parser.js
+++ b/test/unit/support/custom-parser.js
@@ -1,4 +1,6 @@
-module.exports = function (output) {
+module.exports = {
+  name: 'custom parser',
+  parse (output) {
     let failedSpecs = []
     let match = null
     let FAILED_LINES = /custom failure trace: (.*)/g
@@ -9,4 +11,5 @@ module.exports = function (output) {
     }
 
     return failedSpecs
+  }
 }

--- a/test/unit/support/custom-parser.js
+++ b/test/unit/support/custom-parser.js
@@ -1,0 +1,12 @@
+module.exports = function (output) {
+    let failedSpecs = []
+    let match = null
+    let FAILED_LINES = /custom failure trace: (.*)/g
+    while (match = FAILED_LINES.exec(output)) { // eslint-disable-line no-cond-assign
+      if (failedSpecs.indexOf(match[1]) === -1) {
+        failedSpecs.add(match[1])
+      }
+    }
+
+    return failedSpecs
+}


### PR DESCRIPTION
This adds the ability for users to supply a custom parser by: 

- providing the path to a module that will be required, the path must end in a `.*` extension
- providing a custom parsing object (when used programmatically)

This should help in cases where a custom reporter is being used; it allows users to design a parser that fits their needs without having to update protractor-flake itself. 

Eventually it would be nice to provide some tools to make parsing output easier but this is a first step.