### PR TITLE
fix: a spec should not be re-run multiple times if it failed in more than one browser

### DIFF
--- a/src/parsers/multi.js
+++ b/src/parsers/multi.js
@@ -3,7 +3,7 @@ export default {
 
   parse (output) {
     let match = null
-    let failedSpecs = []
+    let failedSpecs = new Set()
     let testsOutput = output.split('------------------------------------')
     let RESULT_REG = /,\s0 failures/g
     let SPECFILE_REG = /.+Specs:\s(.*\.js)/g
@@ -20,11 +20,11 @@ export default {
       }
       if (specfile && result === 'failed') {
         if (!/node_modules/.test(specfile)) {
-          failedSpecs.push(specfile)
+          failedSpecs.add(specfile)
         }
       }
     })
 
-    return failedSpecs
+    return [...failedSpecs]
   }
 }

--- a/test/unit/parsers/multi.test.js
+++ b/test/unit/parsers/multi.test.js
@@ -12,6 +12,14 @@ context('multiParser', function () {
       ])
     })
 
+    it('properly handles a single test that failed in multiple browsers', function () {
+      let output = readFixture('multicapabilities-multifailures-withspecs.txt')
+
+      expect(multiParser.parse(output)).to.eql([
+        '/tests/a-flakey.test.js'
+      ])
+    })
+
     it('properly handles sharded output with a single failure', function () {
       let output = readFixture('sharded-output-single-failure.txt')
 

--- a/test/unit/support/fixtures/multicapabilities-multifailures-withspecs.txt
+++ b/test/unit/support/fixtures/multicapabilities-multifailures-withspecs.txt
@@ -1,0 +1,66 @@
+### Running local browser against local transaction application ###
+Version 3.1.1
+Report destination:   target/reports/report.html
+[launcher] Running 2 instances of WebDriver
+........
+------------------------------------
+[chrome #1] PID: 58317
+[chrome #1] Specs: /tests/a-flakey.test.js
+[chrome #1]
+[chrome #1] /usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/http/util.js:89
+[chrome #1]           Error('Timed out waiting for the WebDriver server at ' + url));
+[chrome #1]           ^
+[chrome #1] Error: Timed out waiting for the WebDriver server at http://127.0.0.1:50845/hub
+[chrome #1]     at Error (native)
+[chrome #1]     at onResponse (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/http/util.js:89:11)
+[chrome #1]     at /usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/http/util.js:44:21
+[chrome #1]     at /usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/webdriver/http/http.js:140:5
+[chrome #1]     at ClientRequest.<anonymous> (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/http/index.js:174:7)
+[chrome #1]     at emitOne (events.js:77:13)
+[chrome #1]     at ClientRequest.emit (events.js:169:7)
+[chrome #1]     at Socket.socketErrorListener (_http_client.js:256:9)
+[chrome #1]     at emitOne (events.js:77:13)
+[chrome #1]     at Socket.emit (events.js:169:7)
+[chrome #1] From: Task: WebDriver.createSession()
+
+[launcher] 1 instance(s) of WebDriver still running
+
+------------------------------------
+[firefox #2] PID: 58318
+[firefox #2] Specs: /tests/a-flakey.test.js
+[firefox #2]
+[firefox #2] Using FirefoxDriver directly...
+[firefox #2]
+[firefox #2] /usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/http/util.js:89
+[firefox #2]           Error('Timed out waiting for the WebDriver server at ' + url));
+[firefox #2]           ^
+[firefox #2] Error: Timed out waiting for the WebDriver server at http://127.0.0.1:50845/hub
+[firefox #2]     at Error (native)
+[firefox #2]     at onResponse (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/http/util.js:89:11)
+[firefox #2]     at /usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/http/util.js:44:21
+[firefox #2]     at /usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/webdriver/http/http.js:140:5
+[firefox #2]     at ClientRequest.<anonymous> (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/http/index.js:174:7)
+[firefox #2]     at emitOne (events.js:77:13)
+[firefox #2]     at ClientRequest.emit (events.js:169:7)
+[firefox #2]     at Socket.socketErrorListener (_http_client.js:256:9)
+[firefox #2]     at emitOne (events.js:77:13)
+[firefox #2]     at Socket.emit (events.js:169:7)
+[firefox #2] From: Task: WebDriver.createSession()
+[firefox #2]     at Function.webdriver.WebDriver.acquireSession_ (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/webdriver/webdriver.js:157:22)
+[firefox #2]     at Function.webdriver.WebDriver.createSession (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/lib/webdriver/webdriver.js:131:30)
+[firefox #2]     at new Driver (/usr/local/lib/node_modules/protractor/node_modules/selenium-webdriver/firefox/index.js:278:36)
+[firefox #2]     at [object Object].DirectDriverProvider.getNewDriver (/usr/local/lib/node_modules/protractor/lib/driverProviders/direct.js:74:16)
+[firefox #2]     at [object Object].Runner.createBrowser (/usr/local/lib/node_modules/protractor/lib/runner.js:190:37)
+[firefox #2]     at /usr/local/lib/node_modules/protractor/lib/runner.js:280:21
+[firefox #2]     at _fulfilled (/usr/local/lib/node_modules/protractor/node_modules/q/q.js:834:54)
+[firefox #2]     at self.promiseDispatch.done (/usr/local/lib/node_modules/protractor/node_modules/q/q.js:863:30)
+[firefox #2]     at Promise.promise.promiseDispatch (/usr/local/lib/node_modules/protractor/node_modules/q/q.js:796:13)
+[firefox #2]     at /usr/local/lib/node_modules/protractor/node_modules/q/q.js:556:49
+
+[launcher] Runner process exited unexpectedly with error code: 1
+[launcher] 0 instance(s) of WebDriver still running
+[launcher] chrome #1 passed
+[launcher] firefox #2 failed with exit code: 1
+[launcher] overall: 1 process(es) failed to complete
+Closing report
+[launcher] Process exited with error code 100


### PR DESCRIPTION
Nick,

Here's a 2nd try at this. I'm still having problems with the integration tests locally, but I don't see how this small change would have any impact on them.

Thanks,
David