### PR TITLE
Notifies protractor that specs are being rerun

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,16 +36,20 @@ export default function (options = {}, callback = function noop () {}) {
           logger.log('info', 'Re-running the following test files:\n')
           logger.log('info', failedSpecs.join('\n') + '\n')
         }
-        return startProtractor(failedSpecs)
+        return startProtractor(failedSpecs, true)
       }
 
       callback(status, output)
     }
   }
 
-  function startProtractor (specFiles = []) {
+  function startProtractor (specFiles = [], retry = false) {
     let output = ''
     let protractorArgs = [parsedOptions.protractorPath].concat(parsedOptions.protractorArgs)
+
+    if (retry) {
+      protractorArgs.push('--params.flake.retry', true)
+    }
 
     if (specFiles.length) {
       protractorArgs = filterArgs(protractorArgs)

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -90,7 +90,7 @@ describe('Protractor Flake', () => {
       spawnStub.dataCallback(failedSingleTestOutput)
       spawnStub.endCallback(1)
 
-      expect(spawnStub).to.have.been.calledWith('node', [pathToProtractor(), '--specs', '/tests/a-flakey.test.js'])
+      expect(spawnStub).to.have.been.calledWith('node', [pathToProtractor(), '--params.flake.retry', true, '--specs', '/tests/a-flakey.test.js'])
     })
 
     it('isolates failed specs for sharded protractor output', () => {
@@ -99,7 +99,7 @@ describe('Protractor Flake', () => {
       spawnStub.dataCallback(failedShardedTestOutput)
       spawnStub.endCallback(1)
 
-      expect(spawnStub).to.have.been.calledWith('node', [pathToProtractor(), '--specs', '/tests/a-flakey.test.js,/tests/another-flakey.test.js'])
+      expect(spawnStub).to.have.been.calledWith('node', [pathToProtractor(), '--params.flake.retry', true, '--specs', '/tests/a-flakey.test.js,/tests/another-flakey.test.js'])
     })
 
     context('with --suite in protractorArgs', function () {
@@ -119,6 +119,7 @@ describe('Protractor Flake', () => {
         expect(spawnStub).to.have.been.calledWith('node', [
           pathToProtractor(),
           '--should-remain=yes',
+          '--params.flake.retry', true,
           '--specs', '/tests/a-flakey.test.js,/tests/another-flakey.test.js'
         ])
       })
@@ -150,6 +151,7 @@ describe('Protractor Flake', () => {
         expect(spawnStub).to.have.been.calledWith('node', [
           pathToProtractor(),
           '--should-remain=yes',
+          '--params.flake.retry', true,
           '--specs', '/tests/a-flakey.test.js,/tests/another-flakey.test.js'
         ])
       })


### PR DESCRIPTION
This PR adds a `--params.flake.retry=true` CLI parameter to protractor when spec files are being rerun. This variable can then be used in protractor for various purposes. In my case, I want to use this variable in a Jasmine reporter for tracking flaky tests.

See https://github.com/angular/protractor/blob/master/lib/config.ts#L455 for use of `--params`

What do you guys think about this feature?