### PR TITLE
chore: Lint commits with conventional-changelog-lint

### DIFF
--- a/.conventional-changelog-lintrc
+++ b/.conventional-changelog-lintrc
@@ -1,0 +1,9 @@
+{
+  "extends": ["angular"],
+  "rules": {
+    "subject-tense": "never",
+    "body-tense": "never",
+    "footer-tense": "never",
+    "lang": "never"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "serve": "bin/www",
     "lint": "standard",
-    "test": "npm run lint && npm run test:unit",
+    "commitcheck": "conventional-changelog-lint --from=HEAD~$(git --no-pager rev-list master..HEAD --count)",
+    "test": "npm run lint && npm run commitcheck && npm run test:unit",
     "test:unit": "mocha --opts test/unit/mocha.opts",
     "test:integration": "npm run build && mocha --opts test/integration/mocha.opts --slow 30001 --timeout 30000 --reporter tap",
     "test:dev": "mocha --watch --opts test/unit/mocha.opts",
@@ -32,6 +33,7 @@
   "devDependencies": {
     "babel": "^5.8.20",
     "chai": "^3.2.0",
+    "conventional-changelog-lint": "^1.1.0",
     "cookie-parser": "^1.3.5",
     "express": "^4.13.1",
     "express-session": "^1.11.3",


### PR DESCRIPTION
This is a pull request to test [`conventional-changelog-lint`](https://github.com/marionebl/conventional-changelog-lint)