### PR TITLE
chore: fix incorrect nodeBin option name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ protractor-flake
 
 # Full options
 # protractor-flake <protractor-flake-options> -- <options to be passed to protractor>
-protractor-flake --protractor-path=/path/to/protractor --parser standard --node-bin node --max-attempts=3 -- path/to/protractor.conf.js
+protractor-flake --protractor-path=/path/to/protractor --parser standard --nodeBin node --max-attempts=3 -- path/to/protractor.conf.js
 ```
 
 Protractor flake expects `protractor` to be on $PATH by default, but you can use the `--protractor-path` argument to point to the protractor executable.


### PR DESCRIPTION
The CLI option to specify a different node bin is `--nodeBin node`