### PR TITLE
fix: add missing node-bin alias

### DIFF
--- a/bin/protractor-flake
+++ b/bin/protractor-flake
@@ -4,7 +4,8 @@ var argv = require('minimist')(process.argv.slice(2), {
   '--': true,
   alias: {
     maxAttempts: 'max-attempts',
-    protractorPath: 'protractor-path'
+    protractorPath: 'protractor-path',
+    nodeBin: 'node-bin'
   }
 });
 


### PR DESCRIPTION
This PR adds the missing `node-bin` alias which is documented in README.md:

`protractor-flake --protractor-path=/path/to/protractor --parser standard --node-bin node --max-attempts=3 --color=magenta -- path/to/protractor.conf.js
`