### PR TITLE
fix: remove origin config from protractorArgs if retryConfig is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ protractorFlake({
   nodeBin: 'node',
   // set color to one of the colors available at 'chalk' - https://github.com/chalk/ansi-styles#colors
   color: 'magenta',
+  // set the arguments for protractor
+  // note: the protractor config have to be the first option in protractorArgs
   protractorArgs: [],
   // specify a different protractor config to apply after the first execution attempt
   // either specify a config file, or cli args (ex. --capabilities.browser=chrome)

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@ export default function (options = {}, callback = function noop () {}) {
     }
 
     if (parsedOptions.protractorRetryConfig && retry) {
+      protractorArgs.splice(1, 1)
       protractorArgs.push(parsedOptions.protractorRetryConfig)
     }
 

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -214,16 +214,16 @@ describe('Protractor Flake', () => {
     })
 
     it('uses protractorRetryConfig file for spawned protractor process only after first attempt', () => {
-      protractorFlake({protractorRetryConfig: __dirname + '/support/protractor.flake.config.js'})
-      expect(spawnStub).to.have.been.calledWith('node', [pathToProtractor(), '--params.flake.iteration', 1])
+      protractorFlake({protractorArgs: [resolve(__dirname + '/support/protractor.flake.config.js')], protractorRetryConfig: resolve(__dirname + '/support/protractor.flake.retryConfig.js')})
+      expect(spawnStub).to.have.been.calledWith('node', [pathToProtractor(), resolve(__dirname + '/support/protractor.flake.config.js'), '--params.flake.iteration', 1])
       spawnStub.dataCallback(failedSingleTestOutput)
       spawnStub.endCallback(1)
-      expect(spawnStub).to.have.been.calledWith('node', [pathToProtractor(), '--params.flake.iteration', 2, '--params.flake.retry', true, '--specs', '/tests/a-flakey.test.js', resolve(__dirname + '/support/protractor.flake.config.js')])
+      expect(spawnStub).to.have.been.calledWith('node', [pathToProtractor(), '--params.flake.iteration', 2, '--params.flake.retry', true, '--specs', '/tests/a-flakey.test.js', resolve(__dirname + '/support/protractor.flake.retryConfig.js')])
     })
 
     it('uses protractorRetryConfig cli args for spawned protractor process only after first attempt', () => {
-      protractorFlake({protractorRetryConfig: '--capabilities.browser=chrome --capabilities.sharding=false'})
-      expect(spawnStub).to.have.been.calledWith('node', [pathToProtractor(), '--params.flake.iteration', 1])
+      protractorFlake({protractorArgs: [resolve(__dirname + '/support/protractor.flake.config.js')], protractorRetryConfig: '--capabilities.browser=chrome --capabilities.sharding=false'})
+      expect(spawnStub).to.have.been.calledWith('node', [pathToProtractor(), resolve(__dirname + '/support/protractor.flake.config.js'), '--params.flake.iteration', 1])
       spawnStub.dataCallback(failedSingleTestOutput)
       spawnStub.endCallback(1)
       expect(spawnStub).to.have.been.calledWith('node', [pathToProtractor(), '--params.flake.iteration', 2, '--params.flake.retry', true, '--specs', '/tests/a-flakey.test.js', '--capabilities.browser=chrome --capabilities.sharding=false'])

--- a/test/unit/support/protractor.flake.retryConfig.js
+++ b/test/unit/support/protractor.flake.retryConfig.js
@@ -1,0 +1,20 @@
+// An example configuration file
+exports.config = {
+  // The address of a running selenium server.
+  seleniumAddress: 'http://localhost:4444/wd/hub',
+
+  // Capabilities to be passed to the webdriver instance.
+  capabilities: {
+    browserName: 'chrome'
+  },
+
+  // Spec patterns are relative to the configuration file location passed
+  // to protractor (in this example conf.js).
+  // They may include glob patterns.
+  specs: ['example-spec.js'],
+
+  // Options to be passed to Jasmine-node.
+  jasmineNodeOpts: {
+    showColors: true // Use colors in the command line report.
+  }
+}


### PR DESCRIPTION
- added a note that the protractor config have to be the first option in protractorArgs.
- Updated the tests for protactorRetryConfig.
- added a retryConfig example for the tests.