### PR TITLE
Always send output to flake callback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ function flake (options: object | undefined = {}, callback: Function | undefined
 
   function handleTestEnd (status: number, output = '') {
     if (status === 0) {
-      callback(status)
+      callback(status, output)
     } else {
       if (++testAttempt <= parsedOptions.maxAttempts) {
         logger.log('info', `\nUsing ${parser.name} to parse output\n`)

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -80,6 +80,17 @@ describe('Protractor Flake', () => {
       spawnStub.endCallback(1)
     })
 
+    it('calls callback with output from protractor process if the status is 0', (done) => {
+      protractorFlake({maxAttempts: 1}, (status: number, output: string) => {
+        expect(status).to.equal(status, 0)
+        expect(output).to.equal('Test')
+        done()
+      })
+
+      spawnStub.dataCallback('Test')
+      spawnStub.endCallback(0)
+    })
+
     it('does not blow up if no callback is passed', function () {
       protractorFlake({maxAttempts: 1})
 


### PR DESCRIPTION
This change ensures that the protractor flake callback will always receive the output log even if the first test pass succeeds with no failures.